### PR TITLE
Add metadata.labels to indentify the source of the log line

### DIFF
--- a/jobs/google-fluentd/templates/google-fluentd.conf
+++ b/jobs/google-fluentd/templates/google-fluentd.conf
@@ -22,4 +22,14 @@
   max_retry_wait 300
   # Disable the limit on the number of retries (retry forever).
   disable_retry_limit
+  # Add metadata.labels to help identify log source
+  labels {
+    "deployment": "<%= spec.deployment %>",
+    "job": "<%= spec.job.name %>",
+    "index": "<%= spec.index %>"
+  }
+  # Move fields from fluentd record into metadata.labels
+  label_map {
+    "log_path": "log_path"
+  }
 </match>

--- a/jobs/google-fluentd/templates/vcap.conf
+++ b/jobs/google-fluentd/templates/vcap.conf
@@ -9,4 +9,5 @@
   pos_file /var/vcap/sys/run/google-fluentd/pos/vcap.pos
   read_from_head true
   tag vcap
+  path_key log_path
 </source>


### PR DESCRIPTION
This PR extends the behaviour of the google-fluentd configuration such that when it forwards the contents of a log from /var/vcap/sys/log/*/*.log it includes metadata so that the log source can be identified.

Specifically, the following metadata attributes are added

- metadata.labels.deployment
- metadata.labels.job
- metadata.labels.index
- metadata.labels.log_path

This enables searching for specific component logs in StackDriver Logging using a search query like:

```
log="vcap" AND metadata.labels.deployment="cf-c201d9fbf59670f9d707" AND metadata.labels.job="uaa" AND metadata.labels.index="0" 
```

![image](https://cloud.githubusercontent.com/assets/227505/20865016/2ffdc472-b9fe-11e6-867b-5b09c1b4ee2e.png)

