### PR TITLE
Activate exception detection on google-fluentd

### DIFF
--- a/jobs/google-fluentd/templates/google-fluentd.conf
+++ b/jobs/google-fluentd/templates/google-fluentd.conf
@@ -33,3 +33,14 @@
     "log_path": "log_path"
   }
 </match>
+
+# Detect exceptions from all sources
+<match **>
+  type detect_exceptions
+  message log
+  stream stream
+  multiline_flush_interval 5
+  max_bytes 500000
+  max_lines 1000
+</match>
+


### PR DESCRIPTION
Enables the plugin introduced by e2c845b

Fixes #64 



Validation
- Deploy dev release, verified logs are still getting into Stackdriver Logging