### PR TITLE
WIP: Timeseries timer buffer

### DIFF
--- a/src/stackdriver-nozzle/config/config.go
+++ b/src/stackdriver-nozzle/config/config.go
@@ -54,7 +54,9 @@ type Config struct {
 	NewlineToken   string `envconfig:"firehose_newline_token"`
 
 	// Stackdriver config
-	ProjectID string `envconfig:"gcp_project_id"`
+	ProjectID             string `envconfig:"gcp_project_id"`
+	MetricsBufferDuration int    `envconfig:"metrics_buffer_duration" default:"30"`
+	MetricsBufferSize     int    `envconfig:"metrics_buffer_size" default:"200"`
 
 	// Nozzle config
 	HeartbeatRate      int  `envconfig:"heartbeat_rate" default:"30"`

--- a/src/stackdriver-nozzle/main.go
+++ b/src/stackdriver-nozzle/main.go
@@ -200,8 +200,7 @@ func (a *app) newMetricSink(ctx context.Context) nozzle.Sink {
 		a.logger.Error("metricAdapter", err)
 	}
 
-	// TODO(evanbrown): Make metrics buffer duration configurable
-	metricBuffer, errs := stackdriver.NewAutoCulledMetricsBuffer(ctx, 30*time.Second, a.c.BatchCount, metricAdapter)
+	metricBuffer, errs := stackdriver.NewAutoCulledMetricsBuffer(ctx, time.Duration(a.c.MetricsBufferDuration)*time.Second, a.c.MetricsBufferSize, metricAdapter)
 	a.bufferEmpty = metricBuffer.IsEmpty
 	go func() {
 		for err = range errs {

--- a/src/stackdriver-nozzle/mocks/metrics_buffer.go
+++ b/src/stackdriver-nozzle/mocks/metrics_buffer.go
@@ -25,3 +25,7 @@ type MetricsBuffer struct {
 func (m *MetricsBuffer) PostMetric(metric *stackdriver.Metric) {
 	m.PostedMetrics = append(m.PostedMetrics, *metric)
 }
+
+func (m *MetricsBuffer) IsEmpty() bool {
+	return true
+}

--- a/src/stackdriver-nozzle/stackdriver/auto_culled_metrics_buffer.go
+++ b/src/stackdriver-nozzle/stackdriver/auto_culled_metrics_buffer.go
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package stackdriver
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+type autoCulledMetricsBuffer struct {
+	adapter MetricAdapter
+	errs    chan error
+	size    int
+	ticker  *time.Ticker
+	ctx     context.Context
+
+	metricsMu sync.Mutex // Guard metrics
+	metrics   metricsMap
+}
+
+func NewAutoCulledMetricsBuffer(ctx context.Context, frequency time.Duration,
+	size int, adapter MetricAdapter) (MetricsBuffer, <-chan error) {
+	errs := make(chan error)
+	mb := &autoCulledMetricsBuffer{
+		adapter: adapter,
+		errs:    errs,
+		metrics: make(map[string]*Metric),
+		size:    size,
+		ctx:     ctx,
+		ticker:  time.NewTicker(frequency),
+	}
+	mb.start()
+	return mb, errs
+}
+
+func (mb *autoCulledMetricsBuffer) PostMetric(metric *Metric) {
+	mb.addMetric(metric)
+}
+
+func (mb *autoCulledMetricsBuffer) IsEmpty() bool {
+	return len(mb.metrics) == 0
+}
+
+func (mb *autoCulledMetricsBuffer) addMetric(newMetric *Metric) {
+	mb.metricsMu.Lock()
+	defer mb.metricsMu.Unlock()
+	mb.metrics[newMetric.Hash()] = newMetric
+}
+
+func (mb *autoCulledMetricsBuffer) start() {
+	go func() {
+		for {
+			select {
+			case <-mb.ticker.C:
+				mb.metricsMu.Lock()
+				l := len(mb.metrics)
+				chunks := l/mb.size + 1
+				var low, high int
+				for i := 0; i < chunks; i++ {
+					low = i * mb.size
+					high = low + mb.size
+					if i == chunks-1 {
+						high = l
+					}
+					err := mb.adapter.PostMetrics(mb.metrics.Slice()[low:high])
+					if err != nil {
+						mb.errs <- err
+					}
+				}
+				mb.metrics = make(map[string]*Metric)
+				mb.metricsMu.Unlock()
+
+			case <-mb.ctx.Done():
+				mb.ticker.Stop()
+				mb.metricsMu.Lock()
+				err := mb.adapter.PostMetrics(mb.metrics.Slice())
+				mb.metricsMu.Unlock()
+				if err != nil {
+					mb.errs <- err
+				}
+				return
+			}
+		}
+	}()
+}

--- a/src/stackdriver-nozzle/stackdriver/auto_culled_metrics_buffer_test.go
+++ b/src/stackdriver-nozzle/stackdriver/auto_culled_metrics_buffer_test.go
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package stackdriver_test
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"time"
+
+	"github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-nozzle/mocks"
+	"github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-nozzle/stackdriver"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("autoCulledMetricsBuffer", func() {
+	var (
+		metricAdapter *mocks.MetricAdapter
+	)
+
+	BeforeEach(func() {
+		metricAdapter = &mocks.MetricAdapter{}
+	})
+
+	It("culls duplicate metrics", func() {
+		d := 100 * time.Millisecond
+		subject, _ := stackdriver.NewAutoCulledMetricsBuffer(context.TODO(), d, 5,
+			metricAdapter)
+
+		subject.PostMetric(&stackdriver.Metric{Name: "a", Value: 1})
+		subject.PostMetric(&stackdriver.Metric{Name: "b", Value: 2})
+		subject.PostMetric(&stackdriver.Metric{Name: "a", Value: 2})
+		Eventually(metricAdapter.GetPostedMetrics).Should(HaveLen(2))
+
+		expected := []stackdriver.Metric{
+			{Name: "a", Value: 2},
+			{Name: "b", Value: 2},
+		}
+		sort.Sort(sortableMetrics(expected))
+		actual := metricAdapter.GetPostedMetrics()
+		sort.Sort(sortableMetrics(actual))
+		Expect(actual).To(BeEquivalentTo(expected))
+
+		subject.PostMetric(&stackdriver.Metric{Name: "c", Value: 1})
+		subject.PostMetric(&stackdriver.Metric{Name: "d", Value: 2, Labels: map[string]string{"d1": "a"}})
+		subject.PostMetric(&stackdriver.Metric{Name: "d", Value: 2, Labels: map[string]string{"d2": "a"}})
+		subject.PostMetric(&stackdriver.Metric{Name: "e", Value: 2, Labels: map[string]string{"a": "a1"}})
+		subject.PostMetric(&stackdriver.Metric{Name: "e", Value: 3, Labels: map[string]string{"a": "a1"}})
+		subject.PostMetric(&stackdriver.Metric{Name: "e", Value: 3, Labels: map[string]string{"a": "a1"}})
+		Eventually(metricAdapter.GetPostedMetrics).Should(HaveLen(6))
+
+		expected = []stackdriver.Metric{
+			{Name: "a", Value: 2},
+			{Name: "b", Value: 2},
+			{Name: "c", Value: 1},
+			{Name: "d", Value: 2, Labels: map[string]string{"d1": "a"}},
+			{Name: "d", Value: 2, Labels: map[string]string{"d2": "a"}},
+			{Name: "e", Value: 3, Labels: map[string]string{"a": "a1"}},
+		}
+		sort.Sort(sortableMetrics(expected))
+		actual = metricAdapter.GetPostedMetrics()
+		sort.Sort(sortableMetrics(actual))
+		Expect(actual).To(BeEquivalentTo(expected))
+	})
+
+	It("it buffers metrics for the expected duration before flushing", func() {
+		d := 500 * time.Millisecond
+		subject, _ := stackdriver.NewAutoCulledMetricsBuffer(context.TODO(), d, 5,
+			metricAdapter)
+
+		subject.PostMetric(&stackdriver.Metric{Name: "a", Value: 1})
+		subject.PostMetric(&stackdriver.Metric{Name: "b", Value: 2})
+		subject.PostMetric(&stackdriver.Metric{Name: "a", Value: 2})
+		Expect(metricAdapter.GetPostedMetrics()).Should(HaveLen(0))
+		Eventually(metricAdapter.GetPostedMetrics).Should(HaveLen(2))
+	})
+
+	It("it flushes metrics when the context is canceled", func() {
+		d := 500 * time.Second
+		ctx, cancel := context.WithCancel(context.Background())
+		subject, _ := stackdriver.NewAutoCulledMetricsBuffer(ctx, d, 5,
+			metricAdapter)
+
+		subject.PostMetric(&stackdriver.Metric{Name: "a", Value: 1})
+		subject.PostMetric(&stackdriver.Metric{Name: "b", Value: 2})
+		subject.PostMetric(&stackdriver.Metric{Name: "a", Value: 2})
+		cancel()
+		Eventually(metricAdapter.GetPostedMetrics).Should(HaveLen(2))
+	})
+
+	It("it posts the metrics  in correct batch size", func() {
+		d := 100 * time.Millisecond
+		ctx, cancel := context.WithCancel(context.Background())
+		subject, _ := stackdriver.NewAutoCulledMetricsBuffer(ctx, d, 3,
+			metricAdapter)
+
+		subject.PostMetric(&stackdriver.Metric{Name: "a", Value: 1})
+		subject.PostMetric(&stackdriver.Metric{Name: "b", Value: 1})
+		subject.PostMetric(&stackdriver.Metric{Name: "c", Value: 1})
+		subject.PostMetric(&stackdriver.Metric{Name: "d", Value: 1})
+		subject.PostMetric(&stackdriver.Metric{Name: "e", Value: 1})
+		cancel()
+		Eventually(metricAdapter.GetPostedMetrics).Should(HaveLen(5))
+	})
+
+	It("sends errors through the error channel", func() {
+		d := 1 * time.Millisecond
+		subject, errs := stackdriver.NewAutoCulledMetricsBuffer(context.TODO(), d, 5,
+			metricAdapter)
+
+		expectedErr := errors.New("fail")
+		metricAdapter.PostMetricError = expectedErr
+
+		metric := &stackdriver.Metric{}
+		subject.PostMetric(metric)
+
+		Eventually(metricAdapter.GetPostedMetrics).Should(HaveLen(1))
+
+		var err error
+		Eventually(errs).Should(Receive(&err))
+		Expect(err).To(Equal(expectedErr))
+	})
+})
+
+type sortableMetrics []stackdriver.Metric
+
+func (b sortableMetrics) Len() int {
+	return len(b)
+}
+func (b sortableMetrics) Swap(i, j int) {
+	b[i], b[j] = b[j], b[i]
+}
+func (b sortableMetrics) Less(i, j int) bool {
+	return b[i].Hash() < b[j].Hash()
+}

--- a/src/stackdriver-nozzle/stackdriver/metric_adapter.go
+++ b/src/stackdriver-nozzle/stackdriver/metric_adapter.go
@@ -17,6 +17,7 @@
 package stackdriver
 
 import (
+	"bytes"
 	"fmt"
 	"path"
 	"sync"
@@ -36,6 +37,16 @@ type Metric struct {
 	Labels    map[string]string
 	EventTime time.Time
 	Unit      string // TODO Should this be "1" if it's empty?
+}
+
+func (m *Metric) Hash() string {
+	var b bytes.Buffer
+	b.Write([]byte(m.Name))
+	for k, v := range m.Labels {
+		b.Write([]byte(k))
+		b.Write([]byte(v))
+	}
+	return b.String()
 }
 
 type MetricAdapter interface {

--- a/src/stackdriver-nozzle/stackdriver/metric_client.go
+++ b/src/stackdriver-nozzle/stackdriver/metric_client.go
@@ -34,9 +34,7 @@ type MetricClient interface {
 
 func NewMetricClient() (MetricClient, error) {
 	ctx := context.Background()
-	sdMetricClient, err := monitoring.NewMetricClient(ctx,
-		option.WithScopes("https://www.googleapis.com/auth/monitoring.write"),
-		option.WithUserAgent(version.UserAgent()))
+	sdMetricClient, err := monitoring.NewMetricClient(ctx, option.WithScopes("https://www.googleapis.com/auth/monitoring.write"), option.WithUserAgent(version.UserAgent()))
 	if err != nil {
 		return nil, err
 	}

--- a/src/stackdriver-nozzle/stackdriver/metric_client.go
+++ b/src/stackdriver-nozzle/stackdriver/metric_client.go
@@ -34,7 +34,9 @@ type MetricClient interface {
 
 func NewMetricClient() (MetricClient, error) {
 	ctx := context.Background()
-	sdMetricClient, err := monitoring.NewMetricClient(ctx, option.WithScopes("https://www.googleapis.com/auth/monitoring.write"), option.WithUserAgent(version.UserAgent()))
+	sdMetricClient, err := monitoring.NewMetricClient(ctx,
+		option.WithScopes("https://www.googleapis.com/auth/monitoring.write"),
+		option.WithUserAgent(version.UserAgent()))
 	if err != nil {
 		return nil, err
 	}

--- a/src/stackdriver-nozzle/stackdriver/metrics_buffer.go
+++ b/src/stackdriver-nozzle/stackdriver/metrics_buffer.go
@@ -16,10 +16,81 @@
 
 package stackdriver
 
-import "reflect"
+import (
+	"context"
+	"github.com/mitchellh/hashstructure"
+	"reflect"
+	"sync"
+	"time"
+)
 
 type MetricsBuffer interface {
 	PostMetric(*Metric)
+}
+
+type timerMetricsBuffer struct {
+	adapter MetricAdapter
+	errs    chan error
+	size    int
+	ticker  *time.Ticker
+	ctx     context.Context
+
+	metricsMu sync.Mutex // Guard metrics
+	metrics   metricsMap
+}
+
+func NewTimerMetricsBuffer(ctx context.Context, frequency time.Duration,
+	size int, adapter MetricAdapter) (MetricsBuffer, <-chan error) {
+	errs := make(chan error)
+	mb := &timerMetricsBuffer{
+		adapter: adapter,
+		errs:    errs,
+		metrics: make(map[string]*Metric),
+		size:    size,
+		ctx:     ctx,
+		ticker:  time.NewTicker(frequency),
+	}
+	mb.start()
+	return mb, errs
+}
+
+func (mb *timerMetricsBuffer) PostMetric(metric *Metric) {
+	mb.addMetric(metric)
+}
+
+func (mb *timerMetricsBuffer) addMetric(newMetric *Metric) {
+	k, _ := hashstructure.Hash(newMetric.Labels, nil)
+	mb.metricsMu.Lock()
+	defer mb.metricsMu.Unlock()
+	mb.metrics[newMetric.Name+string(k)] = newMetric
+}
+
+func (mb *timerMetricsBuffer) start() {
+	go func() {
+		for {
+			select {
+			case <-mb.ticker.C:
+				mb.metricsMu.Lock()
+				// TODO(evanbrown): batch size should be applied here to ensure
+				// we don't exceed the max batch size of the StackDriver API.
+				err := mb.adapter.PostMetrics(mb.metrics.Slice())
+				mb.metrics = make(map[string]*Metric)
+				mb.metricsMu.Unlock()
+				if err != nil {
+					mb.errs <- err
+				}
+			case <-mb.ctx.Done():
+				mb.ticker.Stop()
+				mb.metricsMu.Lock()
+				err := mb.adapter.PostMetrics(mb.metrics.Slice())
+				mb.metricsMu.Unlock()
+				if err != nil {
+					mb.errs <- err
+				}
+				return
+			}
+		}
+	}()
 }
 
 type metricsBuffer struct {
@@ -77,4 +148,16 @@ func (mb *metricsBuffer) postMetrics(metrics []Metric) {
 			mb.errs <- err
 		}
 	}()
+}
+
+type metricsMap map[string]*Metric
+
+func (mm metricsMap) Slice() []Metric {
+	m := make([]Metric, len(mm))
+	var i int
+	for _, v := range mm {
+		m[i] = *v
+		i++
+	}
+	return m
 }

--- a/src/stackdriver-nozzle/stackdriver/metrics_buffer_test.go
+++ b/src/stackdriver-nozzle/stackdriver/metrics_buffer_test.go
@@ -17,42 +17,15 @@
 package stackdriver_test
 
 import (
-	"context"
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-nozzle/mocks"
 	"github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-nozzle/stackdriver"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"sync"
 )
-
-var _ = Describe("TimerMetricsBuffer", func() {
-	var (
-		metricAdapter *mocks.MetricAdapter
-	)
-
-	BeforeEach(func() {
-		metricAdapter = &mocks.MetricAdapter{}
-	})
-
-	It("posts current batch when encounters a duplicate", func() {
-		d := 100 * time.Millisecond
-		subject, _ := stackdriver.NewTimerMetricsBuffer(context.TODO(), d, 5,
-			metricAdapter)
-
-		subject.PostMetric(&stackdriver.Metric{Name: "a", Value: 1})
-		subject.PostMetric(&stackdriver.Metric{Name: "b", Value: 2})
-		subject.PostMetric(&stackdriver.Metric{Name: "a", Value: 2})
-		Eventually(metricAdapter.GetPostedMetrics).Should(HaveLen(2))
-
-		Expect(metricAdapter.GetPostedMetrics()).To(Equal([]stackdriver.Metric{
-			{Name: "a", Value: 2},
-			{Name: "b", Value: 2},
-		}))
-	})
-})
 
 var _ = Describe("MetricsBuffer", func() {
 	var (

--- a/src/stackdriver-nozzle/vendor/github.com/mitchellh/hashstructure/LICENSE
+++ b/src/stackdriver-nozzle/vendor/github.com/mitchellh/hashstructure/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Mitchell Hashimoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/stackdriver-nozzle/vendor/github.com/mitchellh/hashstructure/README.md
+++ b/src/stackdriver-nozzle/vendor/github.com/mitchellh/hashstructure/README.md
@@ -1,0 +1,62 @@
+# hashstructure [![GoDoc](https://godoc.org/github.com/mitchellh/hashstructure?status.svg)](https://godoc.org/github.com/mitchellh/hashstructure)
+
+hashstructure is a Go library for creating a unique hash value
+for arbitrary values in Go.
+
+This can be used to key values in a hash (for use in a map, set, etc.)
+that are complex. The most common use case is comparing two values without
+sending data across the network, caching values locally (de-dup), and so on.
+
+## Features
+
+  * Hash any arbitrary Go value, including complex types.
+
+  * Tag a struct field to ignore it and not affect the hash value.
+
+  * Tag a slice type struct field to treat it as a set where ordering
+    doesn't affect the hash code but the field itself is still taken into
+    account to create the hash value.
+
+  * Optionally specify a custom hash function to optimize for speed, collision
+    avoidance for your data set, etc.
+
+## Installation
+
+Standard `go get`:
+
+```
+$ go get github.com/mitchellh/hashstructure
+```
+
+## Usage & Example
+
+For usage and examples see the [Godoc](http://godoc.org/github.com/mitchellh/hashstructure).
+
+A quick code example is shown below:
+
+```go
+type ComplexStruct struct {
+    Name     string
+    Age      uint
+    Metadata map[string]interface{}
+}
+
+v := ComplexStruct{
+    Name: "mitchellh",
+    Age:  64,
+    Metadata: map[string]interface{}{
+        "car":      true,
+        "location": "California",
+        "siblings": []string{"Bob", "John"},
+    },
+}
+
+hash, err := hashstructure.Hash(v, nil)
+if err != nil {
+    panic(err)
+}
+
+fmt.Printf("%d", hash)
+// Output:
+// 2307517237273902113
+```

--- a/src/stackdriver-nozzle/vendor/github.com/mitchellh/hashstructure/hashstructure.go
+++ b/src/stackdriver-nozzle/vendor/github.com/mitchellh/hashstructure/hashstructure.go
@@ -1,0 +1,335 @@
+package hashstructure
+
+import (
+	"encoding/binary"
+	"fmt"
+	"hash"
+	"hash/fnv"
+	"reflect"
+)
+
+// HashOptions are options that are available for hashing.
+type HashOptions struct {
+	// Hasher is the hash function to use. If this isn't set, it will
+	// default to FNV.
+	Hasher hash.Hash64
+
+	// TagName is the struct tag to look at when hashing the structure.
+	// By default this is "hash".
+	TagName string
+
+	// ZeroNil is flag determining if nil pointer should be treated equal
+	// to a zero value of pointed type. By default this is false.
+	ZeroNil bool
+}
+
+// Hash returns the hash value of an arbitrary value.
+//
+// If opts is nil, then default options will be used. See HashOptions
+// for the default values. The same *HashOptions value cannot be used
+// concurrently. None of the values within a *HashOptions struct are 
+// safe to read/write while hashing is being done. 
+//
+// Notes on the value:
+//
+//   * Unexported fields on structs are ignored and do not affect the
+//     hash value.
+//
+//   * Adding an exported field to a struct with the zero value will change
+//     the hash value.
+//
+// For structs, the hashing can be controlled using tags. For example:
+//
+//    struct {
+//        Name string
+//        UUID string `hash:"ignore"`
+//    }
+//
+// The available tag values are:
+//
+//   * "ignore" or "-" - The field will be ignored and not affect the hash code.
+//
+//   * "set" - The field will be treated as a set, where ordering doesn't
+//             affect the hash code. This only works for slices.
+//
+func Hash(v interface{}, opts *HashOptions) (uint64, error) {
+	// Create default options
+	if opts == nil {
+		opts = &HashOptions{}
+	}
+	if opts.Hasher == nil {
+		opts.Hasher = fnv.New64()
+	}
+	if opts.TagName == "" {
+		opts.TagName = "hash"
+	}
+
+	// Reset the hash
+	opts.Hasher.Reset()
+
+	// Create our walker and walk the structure
+	w := &walker{
+		h:       opts.Hasher,
+		tag:     opts.TagName,
+		zeronil: opts.ZeroNil,
+	}
+	return w.visit(reflect.ValueOf(v), nil)
+}
+
+type walker struct {
+	h       hash.Hash64
+	tag     string
+	zeronil bool
+}
+
+type visitOpts struct {
+	// Flags are a bitmask of flags to affect behavior of this visit
+	Flags visitFlag
+
+	// Information about the struct containing this field
+	Struct      interface{}
+	StructField string
+}
+
+func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
+	t := reflect.TypeOf(0)
+
+	// Loop since these can be wrapped in multiple layers of pointers
+	// and interfaces.
+	for {
+		// If we have an interface, dereference it. We have to do this up
+		// here because it might be a nil in there and the check below must
+		// catch that.
+		if v.Kind() == reflect.Interface {
+			v = v.Elem()
+			continue
+		}
+
+		if v.Kind() == reflect.Ptr {
+			if w.zeronil {
+				t = v.Type().Elem()
+			}
+			v = reflect.Indirect(v)
+			continue
+		}
+
+		break
+	}
+
+	// If it is nil, treat it like a zero.
+	if !v.IsValid() {
+		v = reflect.Zero(t)
+	}
+
+	// Binary writing can use raw ints, we have to convert to
+	// a sized-int, we'll choose the largest...
+	switch v.Kind() {
+	case reflect.Int:
+		v = reflect.ValueOf(int64(v.Int()))
+	case reflect.Uint:
+		v = reflect.ValueOf(uint64(v.Uint()))
+	case reflect.Bool:
+		var tmp int8
+		if v.Bool() {
+			tmp = 1
+		}
+		v = reflect.ValueOf(tmp)
+	}
+
+	k := v.Kind()
+
+	// We can shortcut numeric values by directly binary writing them
+	if k >= reflect.Int && k <= reflect.Complex64 {
+		// A direct hash calculation
+		w.h.Reset()
+		err := binary.Write(w.h, binary.LittleEndian, v.Interface())
+		return w.h.Sum64(), err
+	}
+
+	switch k {
+	case reflect.Array:
+		var h uint64
+		l := v.Len()
+		for i := 0; i < l; i++ {
+			current, err := w.visit(v.Index(i), nil)
+			if err != nil {
+				return 0, err
+			}
+
+			h = hashUpdateOrdered(w.h, h, current)
+		}
+
+		return h, nil
+
+	case reflect.Map:
+		var includeMap IncludableMap
+		if opts != nil && opts.Struct != nil {
+			if v, ok := opts.Struct.(IncludableMap); ok {
+				includeMap = v
+			}
+		}
+
+		// Build the hash for the map. We do this by XOR-ing all the key
+		// and value hashes. This makes it deterministic despite ordering.
+		var h uint64
+		for _, k := range v.MapKeys() {
+			v := v.MapIndex(k)
+			if includeMap != nil {
+				incl, err := includeMap.HashIncludeMap(
+					opts.StructField, k.Interface(), v.Interface())
+				if err != nil {
+					return 0, err
+				}
+				if !incl {
+					continue
+				}
+			}
+
+			kh, err := w.visit(k, nil)
+			if err != nil {
+				return 0, err
+			}
+			vh, err := w.visit(v, nil)
+			if err != nil {
+				return 0, err
+			}
+
+			fieldHash := hashUpdateOrdered(w.h, kh, vh)
+			h = hashUpdateUnordered(h, fieldHash)
+		}
+
+		return h, nil
+
+	case reflect.Struct:
+		var include Includable
+		parent := v.Interface()
+		if impl, ok := parent.(Includable); ok {
+			include = impl
+		}
+
+		t := v.Type()
+		h, err := w.visit(reflect.ValueOf(t.Name()), nil)
+		if err != nil {
+			return 0, err
+		}
+
+		l := v.NumField()
+		for i := 0; i < l; i++ {
+			if v := v.Field(i); v.CanSet() || t.Field(i).Name != "_" {
+				var f visitFlag
+				fieldType := t.Field(i)
+				if fieldType.PkgPath != "" {
+					// Unexported
+					continue
+				}
+
+				tag := fieldType.Tag.Get(w.tag)
+				if tag == "ignore" || tag == "-" {
+					// Ignore this field
+					continue
+				}
+
+				// Check if we implement includable and check it
+				if include != nil {
+					incl, err := include.HashInclude(fieldType.Name, v)
+					if err != nil {
+						return 0, err
+					}
+					if !incl {
+						continue
+					}
+				}
+
+				switch tag {
+				case "set":
+					f |= visitFlagSet
+				}
+
+				kh, err := w.visit(reflect.ValueOf(fieldType.Name), nil)
+				if err != nil {
+					return 0, err
+				}
+
+				vh, err := w.visit(v, &visitOpts{
+					Flags:       f,
+					Struct:      parent,
+					StructField: fieldType.Name,
+				})
+				if err != nil {
+					return 0, err
+				}
+
+				fieldHash := hashUpdateOrdered(w.h, kh, vh)
+				h = hashUpdateUnordered(h, fieldHash)
+			}
+		}
+
+		return h, nil
+
+	case reflect.Slice:
+		// We have two behaviors here. If it isn't a set, then we just
+		// visit all the elements. If it is a set, then we do a deterministic
+		// hash code.
+		var h uint64
+		var set bool
+		if opts != nil {
+			set = (opts.Flags & visitFlagSet) != 0
+		}
+		l := v.Len()
+		for i := 0; i < l; i++ {
+			current, err := w.visit(v.Index(i), nil)
+			if err != nil {
+				return 0, err
+			}
+
+			if set {
+				h = hashUpdateUnordered(h, current)
+			} else {
+				h = hashUpdateOrdered(w.h, h, current)
+			}
+		}
+
+		return h, nil
+
+	case reflect.String:
+		// Directly hash
+		w.h.Reset()
+		_, err := w.h.Write([]byte(v.String()))
+		return w.h.Sum64(), err
+
+	default:
+		return 0, fmt.Errorf("unknown kind to hash: %s", k)
+	}
+
+	return 0, nil
+}
+
+func hashUpdateOrdered(h hash.Hash64, a, b uint64) uint64 {
+	// For ordered updates, use a real hash function
+	h.Reset()
+
+	// We just panic if the binary writes fail because we are writing
+	// an int64 which should never be fail-able.
+	e1 := binary.Write(h, binary.LittleEndian, a)
+	e2 := binary.Write(h, binary.LittleEndian, b)
+	if e1 != nil {
+		panic(e1)
+	}
+	if e2 != nil {
+		panic(e2)
+	}
+
+	return h.Sum64()
+}
+
+func hashUpdateUnordered(a, b uint64) uint64 {
+	return a ^ b
+}
+
+// visitFlag is used as a bitmask for affecting visit behavior
+type visitFlag uint
+
+const (
+	visitFlagInvalid visitFlag = iota
+	visitFlagSet               = iota << 1
+)

--- a/src/stackdriver-nozzle/vendor/github.com/mitchellh/hashstructure/include.go
+++ b/src/stackdriver-nozzle/vendor/github.com/mitchellh/hashstructure/include.go
@@ -1,0 +1,15 @@
+package hashstructure
+
+// Includable is an interface that can optionally be implemented by
+// a struct. It will be called for each field in the struct to check whether
+// it should be included in the hash.
+type Includable interface {
+	HashInclude(field string, v interface{}) (bool, error)
+}
+
+// IncludableMap is an interface that can optionally be implemented by
+// a struct. It will be called when a map-type field is found to ask the
+// struct if the map item should be included in the hash.
+type IncludableMap interface {
+	HashIncludeMap(field string, k, v interface{}) (bool, error)
+}

--- a/src/stackdriver-nozzle/vendor/vendor.json
+++ b/src/stackdriver-nozzle/vendor/vendor.json
@@ -187,6 +187,12 @@
 			"revisionTime": "2016-09-21T17:42:30Z"
 		},
 		{
+			"checksumSHA1": "sWdAYPKyaT4SW8hNQNpRS0sU4lU=",
+			"path": "github.com/mitchellh/hashstructure",
+			"revision": "ab25296c0f51f1022f01cd99dfb45f1775de8799",
+			"revisionTime": "2017-01-16T05:20:23Z"
+		},
+		{
 			"checksumSHA1": "5CYrIFTTUD3pONFo8uEO21Ajz68=",
 			"path": "github.com/onsi/ginkgo",
 			"revision": "45a5f6ffb2a14e4f29698c16ae4c0a34018a8951",


### PR DESCRIPTION
> WIP: needs more unit tests

This change allows metrics to be buffered and drained after a duration.
A duplicate metric (i.e., metric name and labels are identical to an
existing buffered metric) overwrites the existing metric it matches.

Addresses #62