### PR TITLE
format UUID into string for HttpStartStop.RequestId

### DIFF
--- a/src/stackdriver-nozzle/nozzle/log_sink.go
+++ b/src/stackdriver-nozzle/nozzle/log_sink.go
@@ -19,10 +19,11 @@ package nozzle
 import (
 	"encoding/json"
 
+	"strings"
+
 	"cloud.google.com/go/logging"
 	"github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-nozzle/stackdriver"
 	"github.com/cloudfoundry/sonde-go/events"
-	"strings"
 )
 
 func NewLogSink(labelMaker LabelMaker, logAdapter stackdriver.LogAdapter, newlineToken string) Sink {
@@ -92,6 +93,7 @@ func (ls *logSink) parseEnvelope(envelope *events.Envelope) stackdriver.Log {
 		if httpStartStopMap != nil {
 			httpStartStopMap["method"] = httpStartStop.GetMethod().String()
 			httpStartStopMap["peerType"] = httpStartStop.GetPeerType().String()
+			httpStartStopMap["requestId"] = formatUUID(httpStartStop.GetRequestId())
 			payload["httpStartStop"] = httpStartStopMap
 		}
 	}

--- a/src/stackdriver-nozzle/nozzle/log_sink_test.go
+++ b/src/stackdriver-nozzle/nozzle/log_sink_test.go
@@ -37,7 +37,7 @@ var _ = Describe("LogSink", func() {
 	)
 
 	BeforeEach(func() {
-		labels = map[string]string{"foo": "bar", "applicationId": "f47ac10b-58cc-4372-a567-0e02b2c3d479"}
+		labels = map[string]string{"foo": "bar", "applicationId": "ab313b25-aa48-4a8f-8e7d-d63a6d410e7c"}
 		labelMaker = &mocks.LabelMaker{Labels: labels}
 		logAdapter = &mocks.LogAdapter{}
 
@@ -98,9 +98,16 @@ var _ = Describe("LogSink", func() {
 		It("handles HttpStartStop", func() {
 			method := events.Method_GET
 			peerType := events.PeerType_Client
+			var low uint64 = 0x7243cc580bc17af4
+			var high uint64 = 0x79d4c3b2020e67a5
+			requestId := events.UUID{
+				Low:  &low,
+				High: &high,
+			}
 			event := events.HttpStartStop{
-				Method:   &method,
-				PeerType: &peerType,
+				Method:    &method,
+				PeerType:  &peerType,
+				RequestId: &requestId,
 			}
 
 			eventType := events.Envelope_HttpStartStop
@@ -116,11 +123,12 @@ var _ = Describe("LogSink", func() {
 			Expect(payload).To(HaveKeyWithValue("eventType", "HttpStartStop"))
 			Expect(payload).To(HaveKey("httpStartStop"))
 			Expect(payload).To(HaveKeyWithValue("httpStartStop", map[string]interface{}{
-				"method":   "GET",
-				"peerType": "Client",
+				"method":    "GET",
+				"peerType":  "Client",
+				"requestId": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
 			}))
 			Expect(payload).To(HaveKeyWithValue("serviceContext", map[string]interface{}{
-				"service": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+				"service": "ab313b25-aa48-4a8f-8e7d-d63a6d410e7c",
 			}))
 		})
 
@@ -150,7 +158,7 @@ var _ = Describe("LogSink", func() {
 				},
 				"message": "19400: Success: Go",
 				"serviceContext": map[string]interface{}{
-					"service": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+					"service": "ab313b25-aa48-4a8f-8e7d-d63a6d410e7c",
 				},
 			}))
 			Expect(postedLog.Severity).To(Equal(logging.Default))


### PR DESCRIPTION
Verified the output now looks like:
```
 httpStartStop: {
   contentLength: 91
   uri: "https://api.cf.jrjohnson-kubo.cloudnativeapp.com/v2/syslog_drain_urls"
   remoteAddress: "10.138.3.17:46394"
   method: "GET"
   startTimestamp: 1487098222367823000
   userAgent: "Go-http-client/1.1"
>   requestId: "64ba1ea5-17ec-4b6d-7825-17a2536eaab8"
   statusCode: 500
   stopTimestamp: 1487098222378248400
   peerType: "Server"
  }
```
Fixes #60


I used the `applicationId` UUID for the requestId because it's a known example of how to go from events.UUID to a string.  Updated the applicationId to a new UUID to keep it unique. 