### PR TITLE
Add monitoring roles to requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,16 +53,13 @@ links to request even higher quotas.
 All of the jobs in this release authenticate to Stackdriver Logging and
 Monitoring via [Service
 Accounts](https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances).
-You must create a service account with the following roles:
+Follow the [GCP documentation](https://cloud.google.com/iam/docs/granting-changing-revoking-access) to create a service account via gcloud with the following roles:
 
-- `roles/logging.logWriter` to stream logs to Stackdriver Logging
-- `roles/logging.configWriter` to setup CloudFoundry specific metrics on
-  Stackdriver Monitoring
+- `roles/logging.logWriter`
+- `roles/logging.configWriter`
+- `roles/monitoring.metricWriter`
 
-The BOSH resource pool you deploy the job(s) to must use that service account
-by specifying it in `cloud_properties`. The [BOSH Google CPI
-documentation](https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances)
-describes how to set the `service_account` for a resource pool.
+You can either authenticate the job(s) by specifying the service account in the `cloud_properties` for the [resource pool](https://bosh.io/docs/deployment-manifest.html#resource-pools) running the job(s) or by configuring and colocating the [credentials](https://github.com/cloudfoundry-community/stackdriver-tools/blob/master/jobs/credentials/spec) job. 
 
 You may also read the [access control
 documentation](https://cloud.google.com/logging/docs/access-control) for more


### PR DESCRIPTION
Clean up this section a bit and mention the credentials job.

Merging this directly to master as it's a doc update and not dependent on anything in develop. 

Fixes #82