### PR TITLE
PR: Remove credentials job from nozzle tile

### DIFF
--- a/jobs/credentials/templates/pre-start.erb
+++ b/jobs/credentials/templates/pre-start.erb
@@ -9,7 +9,3 @@ cp ${JOB_DIR}/config/application_default_credentials.json $HOME/.config/gcloud/
 # for metrics agent
 mkdir -p /etc/google/auth/
 cp ${JOB_DIR}/config/application_default_credentials.json /etc/google/auth/ 
-
-# for nozzle (runs as vcap)
-sudo su -c 'mkdir -p /home/vcap/.config/gcloud/' vcap
-cp ${JOB_DIR}/config/application_default_credentials.json /home/vcap/.config/gcloud/

--- a/jobs/stackdriver-nozzle/spec
+++ b/jobs/stackdriver-nozzle/spec
@@ -2,6 +2,7 @@
 name: stackdriver-nozzle
 templates:
   stackdriver-nozzle-ctl.erb: bin/stackdriver-nozzle-ctl
+  application_default_credentials.json.erb: config/application_default_credentials.json
 
 packages:
   - stackdriver-nozzle
@@ -28,6 +29,9 @@ properties:
 
   gcp.project_id:
     description: Google Cloud Platform project ID (optional if on GCP)
+
+  credentials.application_default_credentials:
+    description: Contents of application_default_credentials.json, see https://cloud.google.com/logging/docs/agent/authorization#configuring_client_id_authorization.
 
   nozzle.debug:
     description: Enable debug features for the stackdriver-nozzle for development or troubleshooting

--- a/jobs/stackdriver-nozzle/templates/application_default_credentials.json.erb
+++ b/jobs/stackdriver-nozzle/templates/application_default_credentials.json.erb
@@ -1,0 +1,3 @@
+<% if_p('credentials.application_default_credentials') do |prop| %>
+<%=prop%>
+<% end %>

--- a/jobs/stackdriver-nozzle/templates/stackdriver-nozzle-ctl.erb
+++ b/jobs/stackdriver-nozzle/templates/stackdriver-nozzle-ctl.erb
@@ -50,7 +50,7 @@ case $1 in
 
   *)
 
-    echo "Usage: stackdriver-nozzle {start|stop}"
+    echo "Usage: stackdriver-nozzle-ctl {start|stop}"
 
     ;;
 

--- a/jobs/stackdriver-nozzle/templates/stackdriver-nozzle-ctl.erb
+++ b/jobs/stackdriver-nozzle/templates/stackdriver-nozzle-ctl.erb
@@ -2,6 +2,7 @@
 
 RUN_DIR=/var/vcap/sys/run/stackdriver-nozzle
 LOG_DIR=/var/vcap/sys/log/stackdriver-nozzle
+PKG_DIR=/var/vcap/packages/stackdriver-nozzle
 PIDFILE=$RUN_DIR/stackdriver-nozzle.pid
 
 source /var/vcap/packages/common/utils.sh
@@ -33,10 +34,13 @@ case $1 in
     <% if_p('gcp.project_id') do |prop| %>
     export GCP_PROJECT_ID=<%= prop %>
     <% end %>
+    <% if_p('credentials.application_default_credentials') do |prop| %>
+    export GOOGLE_APPLICATION_CREDENTIALS=$PKG_DIR/config/application_default_credentials.json
+    <% end %>
 
     echo $$ > $PIDFILE
 
-    exec chpst -u vcap:vcap /var/vcap/packages/stackdriver-nozzle/bin/stackdriver-nozzle \
+    exec chpst -u vcap:vcap $PKG_DIR/bin/stackdriver-nozzle \
       >>$LOG_DIR/stackdriver-nozzle.stdout.log \
       2>>$LOG_DIR/stackdriver-nozzle.stderr.log
 

--- a/tile.yml.erb
+++ b/tile.yml.erb
@@ -14,8 +14,6 @@ packages:
   jobs:
   - name: stackdriver-nozzle
     templates:
-    - name: credentials
-      release: stackdriver-tools
     - name: stackdriver-nozzle
       release: stackdriver-tools
     memory: 512

--- a/tile.yml.erb
+++ b/tile.yml.erb
@@ -33,7 +33,8 @@ packages:
         skip_ssl: (( .properties.firehose_skip_ssl.value ))
       credentials:
         application_default_credentials: (( .properties.service_account.value ))
-      project_id: (( .properties.project_id.value ))
+      gcp:
+        project_id: (( .properties.project_id.value ))
 
 
 forms:


### PR DESCRIPTION
Credentials now handled by the `stackdriver-nozzle` job. 