### PR TITLE
Revert "nozzle/metric_sink: emit instanceIndex as a label"

### DIFF
--- a/src/stackdriver-nozzle/nozzle/metric_sink.go
+++ b/src/stackdriver-nozzle/nozzle/metric_sink.go
@@ -60,9 +60,9 @@ func (ms *metricSink) Receive(envelope *events.Envelope) error {
 		}}
 	case events.Envelope_ContainerMetric:
 		containerMetric := envelope.GetContainerMetric()
-		labels["instanceIndex"] = fmt.Sprintf("%d", containerMetric.GetInstanceIndex())
 		metrics = []stackdriver.Metric{
 			{Name: "diskBytesQuota", Value: float64(containerMetric.GetDiskBytesQuota()), EventTime: eventTime, Labels: labels},
+			{Name: "instanceIndex", Value: float64(containerMetric.GetInstanceIndex()), EventTime: eventTime, Labels: labels},
 			{Name: "cpuPercentage", Value: float64(containerMetric.GetCpuPercentage()), EventTime: eventTime, Labels: labels},
 			{Name: "diskBytes", Value: float64(containerMetric.GetDiskBytes()), EventTime: eventTime, Labels: labels},
 			{Name: "memoryBytes", Value: float64(containerMetric.GetMemoryBytes()), EventTime: eventTime, Labels: labels},

--- a/src/stackdriver-nozzle/nozzle/metric_sink_test.go
+++ b/src/stackdriver-nozzle/nozzle/metric_sink_test.go
@@ -19,8 +19,6 @@ package nozzle_test
 import (
 	"time"
 
-	"fmt"
-
 	"github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-nozzle/mocks"
 	"github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-nozzle/nozzle"
 	"github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-nozzle/stackdriver"
@@ -94,7 +92,7 @@ var _ = Describe("MetricSink", func() {
 		eventTime := time.Now()
 
 		diskBytesQuota := uint64(1073741824)
-		instanceIndex := int32(3)
+		instanceIndex := int32(0)
 		cpuPercentage := 0.061651273460637
 		diskBytes := uint64(164634624)
 		memoryBytes := uint64(16601088)
@@ -123,20 +121,14 @@ var _ = Describe("MetricSink", func() {
 		Expect(err).To(BeNil())
 
 		metrics := metricBuffer.PostedMetrics
-		Expect(metrics).To(HaveLen(5))
+		Expect(metrics).To(HaveLen(6))
 
-		// ContainerMetric has special labels to specify the specific container
-		expectedLabels := map[string]string{}
-		for k, v := range labels {
-			expectedLabels[k] = v
-		}
-		expectedLabels["instanceIndex"] = fmt.Sprintf("%v", instanceIndex)
-
-		Expect(metrics).To(ContainElement(stackdriver.Metric{Name: "diskBytesQuota", Value: float64(1073741824), Labels: expectedLabels, EventTime: eventTime, Unit: ""}))
-		Expect(metrics).To(ContainElement(stackdriver.Metric{Name: "cpuPercentage", Value: 0.061651273460637, Labels: expectedLabels, EventTime: eventTime, Unit: ""}))
-		Expect(metrics).To(ContainElement(stackdriver.Metric{Name: "diskBytes", Value: float64(164634624), Labels: expectedLabels, EventTime: eventTime, Unit: ""}))
-		Expect(metrics).To(ContainElement(stackdriver.Metric{Name: "memoryBytes", Value: float64(16601088), Labels: expectedLabels, EventTime: eventTime, Unit: ""}))
-		Expect(metrics).To(ContainElement(stackdriver.Metric{Name: "memoryBytesQuota", Value: float64(33554432), Labels: expectedLabels, EventTime: eventTime, Unit: ""}))
+		Expect(metrics).To(ContainElement(stackdriver.Metric{Name: "diskBytesQuota", Value: float64(1073741824), Labels: labels, EventTime: eventTime, Unit: ""}))
+		Expect(metrics).To(ContainElement(stackdriver.Metric{Name: "instanceIndex", Value: float64(0), Labels: labels, EventTime: eventTime, Unit: ""}))
+		Expect(metrics).To(ContainElement(stackdriver.Metric{Name: "cpuPercentage", Value: 0.061651273460637, Labels: labels, EventTime: eventTime, Unit: ""}))
+		Expect(metrics).To(ContainElement(stackdriver.Metric{Name: "diskBytes", Value: float64(164634624), Labels: labels, EventTime: eventTime, Unit: ""}))
+		Expect(metrics).To(ContainElement(stackdriver.Metric{Name: "memoryBytes", Value: float64(16601088), Labels: labels, EventTime: eventTime, Unit: ""}))
+		Expect(metrics).To(ContainElement(stackdriver.Metric{Name: "memoryBytesQuota", Value: float64(33554432), Labels: labels, EventTime: eventTime, Unit: ""}))
 	})
 
 	It("creates total and delta metrics for CounterEvent", func() {


### PR DESCRIPTION
Reverts cloudfoundry-community/stackdriver-tools#102

This exceeds Stackdriver's limit of 10 labels per metric