### PR TITLE
bosh-release: update to go1.9

### DIFF
--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update; apt-get -y upgrade; apt-get clean
 RUN apt-get -y install build-essential git-core curl wget jq sudo; apt-get clean
 
 # Install Golang
-ENV GOLANG_VERSION 1.7.1
+ENV GOLANG_VERSION 1.9
 RUN curl -sSL https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz | tar -v -C /usr/local -xz
 ENV GOROOT /usr/local/go
 ENV PATH $PATH:$GOROOT/bin

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,60 +1,56 @@
-golang/go1.6.linux-amd64.tar.gz:
-  size: 84799480
-  object_id: 31e2aa40-56be-44e6-a01d-a2ee5f25337b
-  sha: 01a6a28dbe31a53103b600979bbbbd63a8104456
-golang/go1.7.1.linux-amd64.tar.gz:
-  size: 81618401
-  object_id: e78481ab-9a69-4116-8b99-06d3518232c5
-  sha: 919ab01305ada0078a9fdf8a12bb56fb0b8a1444
+golang/go1.9.linux-amd64.tar.gz:
+  size: 102601309
+  object_id: 9389191f-2e77-4df2-6ccd-d4a1639ed201
+  sha: 6a00c39435edc1e102f1fb75cc1137fba4c9e4e2
 google-fluentd-vendor/google-fluentd-vendor-0.12-plugin-0.5.3.tgz:
   size: 12407170
-  object_id: e5955cd8-e004-49f9-5a83-a546114d442d
+  object_id: da306bf9-a23c-46cc-69e7-7e86a54e7bbb
   sha: 8d00c8753e3d98e0e8a56f91acca54eaec88c277
 google-fluentd-vendor/google-fluentd-vendor-0.14.tgz:
   size: 5099520
-  object_id: 8e8f347b-208f-4d71-be3b-c347acccd833
+  object_id: ad88f6c7-fd8d-41ae-6109-65e3f604e76f
   sha: 9eb9504e3eef812eac7ea5e5f61a038c893544f4
 libtool/libtool-2.4.2.tar.gz:
   size: 2632347
-  object_id: 2e2677e4-06fd-4a5a-b2d1-45c3c2984867
+  object_id: a72448bd-9ae1-482a-54f3-a73f6820c2c4
   sha: 22b71a8b5ce3ad86e1094e7285981cae10e6ff88
 libyajl/yajl-2.1.0.tar.gz:
   size: 84039
-  object_id: 98602cdb-974d-4df1-8b21-e080f80aae10
+  object_id: 0a77c971-4860-4059-5bb7-8b3e0049f2ff
   sha: fe6b3c7439b26175aee59cabf8c4923b9eb3650d
 python/Python-2.7.11.tgz:
   size: 16856409
-  object_id: b2676f74-87a8-4708-bd78-e478705b3b33
+  object_id: 5436eeb5-0322-4aff-5eac-a335d0ee2c72
   sha: 62a0b1b703d42999cc4aa9ee3c55eb7efe35802a
 python/netifaces-0.10.4.tar.gz:
   size: 22969
-  object_id: d4b7d301-60b0-4e2e-a515-074d296199d9
+  object_id: 7f3b60f2-f5ad-422e-708e-91d1e49be6f8
   sha: c3fcd491a89c2994815053e853b005e7fc27c79a
 python/psutil-1.2.1.tar.gz:
   size: 167397
-  object_id: 65957b56-b096-4a79-8354-504a76abd69a
+  object_id: 4e341411-e85b-453e-6a01-03b259700b57
   sha: c8c1842bf1c63b9068ac25a37f7aae11fcecd57f
 python/setuptools-20.4.tar.gz:
   size: 675976
-  object_id: 3d76e562-5b43-4828-9194-532b30726ec1
+  object_id: ff2e938d-6ce7-4514-4d9f-a7197564f7af
   sha: b9ffbf5e29765c4a786c7242be1b03bfe08ad1c0
 ruby/bundler-1.10.6.gem:
   size: 251392
-  object_id: fed164c4-df81-4e9b-89e2-2f1f3d2fb87d
+  object_id: 810385aa-b9c4-4bb0-6f3b-446772507496
   sha: 55a37fccd1c0cb5542d468e35d3be46dd0667f73
 ruby/ruby-2.3.0.tar.gz:
   size: 17648682
-  object_id: a85650d1-5429-4e28-af88-0074dd7581cb
+  object_id: 6b96ba17-ffbe-4d9a-7726-c695c1f4efc4
   sha: 2dfcf7f33bda4078efca30ae28cb89cd0e36ddc4
 ruby/rubygems-2.6.2.tgz:
   size: 478660
-  object_id: 3a22fc58-dce2-430e-ab28-9f2d4be98e2b
+  object_id: 90ddc55c-9119-42c7-5c8d-cc610dc5c6d8
   sha: 5960628b1f90f4a05ed69c0ad59c59cb10b79e5f
 ruby/yaml-0.1.6.tar.gz:
   size: 503012
-  object_id: 12a6045c-c545-4398-b02c-9361694c0352
+  object_id: fbd1083b-6f50-40d8-452a-d0c351326e40
   sha: f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d
 stackdriver-agent/stackdriver-agent_5.5.2-347.tgz:
   size: 1085047
-  object_id: ba5064b6-9690-4757-8bc6-a1cf43d0f13f
+  object_id: f748aeb7-e248-4eab-4969-57fd48000575
   sha: 862df2ed4a2558086df9491231068075b2495026

--- a/config/final.yml
+++ b/config/final.yml
@@ -3,7 +3,7 @@ final_name: stackdriver-tools
 blobstore:
   provider: s3
   options:
-    bucket_name: gcp-tools-release
+    bucket_name: stackdriver-tools-blobs
     host: storage.googleapis.com
     use_ssl: true
     endpoint: https://storage.googleapis.com

--- a/packages/golang/packaging
+++ b/packages/golang/packaging
@@ -3,7 +3,7 @@
 set -e # exit immediately if a simple command exits with a non-zero status
 set -u # report the usage of uninitialized variables
 
-tar xzvf ${BOSH_COMPILE_TARGET}/golang/go1.7.1.linux-amd64.tar.gz
+tar xzvf ${BOSH_COMPILE_TARGET}/golang/go1.9.linux-amd64.tar.gz
 
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
 cp -a ${BOSH_COMPILE_TARGET}/go/* ${BOSH_INSTALL_TARGET}

--- a/packages/golang/spec
+++ b/packages/golang/spec
@@ -1,4 +1,4 @@
 ---
 name: golang
 files:
-  - golang/go1.7.1.linux-amd64.tar.gz
+  - golang/go1.9.linux-amd64.tar.gz


### PR DESCRIPTION
- remove unused go1.6
- replace go1.7 with go1.9
- update dockerfile, needs built: related #108
- had to move the blobstore due to access, related: #109