### PR TITLE
Nozzle Reliability Improvements

### DIFF
--- a/src/stackdriver-nozzle/app/builder.go
+++ b/src/stackdriver-nozzle/app/builder.go
@@ -40,7 +40,7 @@ func New(c *config.Config, logger lager.Logger) *App {
 	// to send heartbeat metrics to Stackdriver. This metricAdapter
 	// has its own heartbeater (with its own trigger) that writes to a logger.
 	trigger := time.NewTicker(time.Duration(c.HeartbeatRate) * time.Second).C
-	adapterHeartbeater := heartbeat.NewHeartbeater(logger, trigger)
+	adapterHeartbeater := heartbeat.NewHeartbeater(logger, trigger, "heartbeater.telemetry.emitted")
 	adapterHeartbeater.Start()
 	metricAdapter, err := stackdriver.NewMetricAdapter(c.ProjectID, metricClient, adapterHeartbeater)
 	if err != nil {
@@ -52,7 +52,7 @@ func New(c *config.Config, logger lager.Logger) *App {
 	// to write to Stackdriver.
 	metricHandler := heartbeat.NewMetricHandler(metricAdapter, logger, c.NozzleId, c.NozzleName, c.NozzleZone)
 	trigger2 := time.NewTicker(time.Duration(c.HeartbeatRate) * time.Second).C
-	heartbeater := heartbeat.NewLoggerMetricHeartbeater(metricHandler, logger, trigger2)
+	heartbeater := heartbeat.NewLoggerMetricHeartbeater(metricHandler, logger, trigger2, "heartbeater.telemetry")
 
 	cfConfig := &cfclient.Config{
 		ApiAddress:        c.APIEndpoint,

--- a/src/stackdriver-nozzle/app/builder.go
+++ b/src/stackdriver-nozzle/app/builder.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cloudfoundry-community/go-cfclient"
+	cfclient "github.com/cloudfoundry-community/go-cfclient"
 	"github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-nozzle/cloudfoundry"
 	"github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-nozzle/config"
 	"github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-nozzle/heartbeat"
@@ -153,7 +153,7 @@ func (a *App) newMetricAdapter() stackdriver.MetricAdapter {
 }
 
 func (a *App) newMetricSink(ctx context.Context, metricAdapter stackdriver.MetricAdapter) nozzle.Sink {
-	metricBuffer, errs := metrics_pipeline.NewAutoCulledMetricsBuffer(ctx, a.logger, time.Duration(a.c.MetricsBufferDuration)*time.Second, a.c.MetricsBufferSize, metricAdapter)
+	metricBuffer, errs := metrics_pipeline.NewAutoCulledMetricsBuffer(ctx, a.logger, time.Duration(a.c.MetricsBufferDuration)*time.Second, a.c.MetricsBufferSize, metricAdapter, a.heartbeater)
 	a.bufferEmpty = metricBuffer.IsEmpty
 	go func() {
 		for err := range errs {

--- a/src/stackdriver-nozzle/app/runner.go
+++ b/src/stackdriver-nozzle/app/runner.go
@@ -38,11 +38,13 @@ func Run(ctx context.Context, a *App) {
 
 	errs, fhErrs := consumer.Start(producer)
 	go func() {
-		select {
-		case err := <-errs:
-			a.logger.Error("nozzle", err)
-		case err := <-fhErrs:
-			a.logger.Error("firehose", err)
+		for {
+			select {
+			case err := <-errs:
+				a.logger.Error("nozzle", err)
+			case err := <-fhErrs:
+				a.logger.Error("firehose", err)
+			}
 		}
 	}()
 

--- a/src/stackdriver-nozzle/app/runner.go
+++ b/src/stackdriver-nozzle/app/runner.go
@@ -5,7 +5,10 @@ import (
 	"fmt"
 	"net/http"
 	_ "net/http/pprof"
+	"os"
+	"os/signal"
 	"runtime"
+
 	"time"
 
 	"cloud.google.com/go/logging"
@@ -16,7 +19,6 @@ import (
 
 func Run(ctx context.Context, a *App) {
 	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
 
 	if a.c.DebugNozzle {
 		defer handleFatalError(a, cancel)
@@ -35,32 +37,44 @@ func Run(ctx context.Context, a *App) {
 	}
 
 	errs, fhErrs := consumer.Start(producer)
-	defer func() {
-		if err := consumer.Stop(); err != nil {
-			a.logger.Error("nozzle.stop", err)
-		}
-	}()
-
 	go func() {
-		for err := range errs {
+		select {
+		case err := <-errs:
 			a.logger.Error("nozzle", err)
+		case err := <-fhErrs:
+			a.logger.Error("firehose", err)
 		}
 	}()
 
-	if fatalErr := <-fhErrs; fatalErr != nil {
-		cancel()
-		t := time.NewTimer(5 * time.Second)
-		for {
-			select {
-			case <-time.Tick(100 * time.Millisecond):
-				if a.bufferEmpty() {
-					a.logger.Fatal("firehose", fatalErr, lager.Data{"cleanup": "The metrics buffer was successfully flushed before shutdown"})
-				}
-			case <-t.C:
-				a.logger.Fatal("firehose", fatalErr, lager.Data{"cleanup": "The metrics buffer could not be flushed before shutdown"})
+	blockTillInterrupt()
+
+	a.logger.Info("app", lager.Data{"cleanup": "exit recieved, attempting to flush buffers"})
+	if err := consumer.Stop(); err != nil {
+		a.logger.Error("nozzle.stop", err)
+	}
+	cancel()
+
+	t := time.NewTimer(5 * time.Second)
+	for {
+		select {
+		case <-time.Tick(500 * time.Millisecond):
+			if a.bufferEmpty() {
+				a.logger.Info("app", lager.Data{"cleanup": "The metrics buffer was successfully flushed before shutdown"})
+				return
 			}
+		case <-t.C:
+			a.logger.Info("app", lager.Data{"cleanup": "The metrics buffer could not be flushed before shutdown"})
+			return
 		}
 	}
+}
+
+func blockTillInterrupt() {
+	c := make(chan os.Signal, 1)
+	defer close(c)
+	signal.Notify(c, os.Interrupt)
+	<-c
+	signal.Stop(c)
 }
 
 func handleFatalError(a *App, cancel context.CancelFunc) {

--- a/src/stackdriver-nozzle/cloudfoundry/firehose.go
+++ b/src/stackdriver-nozzle/cloudfoundry/firehose.go
@@ -53,7 +53,7 @@ func (c *firehose) Connect() (<-chan *events.Envelope, <-chan error) {
 	refresher := cfClientTokenRefresh{cfClient: c.cfClient}
 	cfConsumer.SetIdleTimeout(time.Duration(30) * time.Second)
 	cfConsumer.RefreshTokenFrom(&refresher)
-	return cfConsumer.FirehoseWithoutReconnect(c.subscriptionID, "")
+	return cfConsumer.Firehose(c.subscriptionID, "")
 }
 
 type cfClientTokenRefresh struct {

--- a/src/stackdriver-nozzle/heartbeat/heartbeater.go
+++ b/src/stackdriver-nozzle/heartbeat/heartbeater.go
@@ -45,10 +45,10 @@ type heartbeater struct {
 	handlers []Handler
 }
 
-func NewHeartbeater(logger lager.Logger, trigger <-chan time.Time) Heartbeater {
+func NewHeartbeater(logger lager.Logger, trigger <-chan time.Time, prefix string) Heartbeater {
 	counter := make(chan string)
 	done := make(chan struct{})
-	loggerHandler := NewLoggerHandler(logger)
+	loggerHandler := NewLoggerHandler(logger, prefix)
 	return &heartbeater{
 		trigger: trigger,
 		counter: counter,
@@ -61,10 +61,10 @@ func NewHeartbeater(logger lager.Logger, trigger <-chan time.Time) Heartbeater {
 	}
 }
 
-func NewLoggerMetricHeartbeater(metricHandler Handler, logger lager.Logger, trigger <-chan time.Time) Heartbeater {
+func NewLoggerMetricHeartbeater(metricHandler Handler, logger lager.Logger, trigger <-chan time.Time, prefix string) Heartbeater {
 	counter := make(chan string)
 	done := make(chan struct{})
-	loggerHandler := NewLoggerHandler(logger)
+	loggerHandler := NewLoggerHandler(logger, prefix)
 	return &heartbeater{
 		trigger: trigger,
 		counter: counter,

--- a/src/stackdriver-nozzle/heartbeat/heartbeater_test.go
+++ b/src/stackdriver-nozzle/heartbeat/heartbeater_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Heartbeater", func() {
 		metricAdapter, _ = stackdriver.NewMetricAdapter("my-awesome-project", client, heartbeater)
 		metricHandler = heartbeat.NewMetricHandler(metricAdapter, logger, "nozzle-id", "nozzle-name", "nozle-zone")
 
-		subject = heartbeat.NewLoggerMetricHeartbeater(metricHandler, logger, trigger)
+		subject = heartbeat.NewLoggerMetricHeartbeater(metricHandler, logger, trigger, "heartbeater")
 		subject.Start()
 	})
 

--- a/src/stackdriver-nozzle/heartbeat/logger_handler.go
+++ b/src/stackdriver-nozzle/heartbeat/logger_handler.go
@@ -24,15 +24,17 @@ import (
 
 type loggerHandler struct {
 	logger lager.Logger
+	prefix string
 
 	counterMu sync.Mutex // Guards counter
 	counter   map[string]uint
 }
 
-func NewLoggerHandler(logger lager.Logger) *loggerHandler {
+func NewLoggerHandler(logger lager.Logger, prefix string) *loggerHandler {
 	return &loggerHandler{
 		logger:  logger,
 		counter: map[string]uint{},
+		prefix:  prefix,
 	}
 }
 
@@ -51,7 +53,7 @@ func (h *loggerHandler) Flush() error {
 	h.counterMu.Lock()
 	defer h.counterMu.Unlock()
 	h.logger.Info(
-		"heartbeater", lager.Data{"counters": h.counter},
+		h.prefix, lager.Data{"counters": h.counter},
 	)
 	h.counter = map[string]uint{}
 	return nil

--- a/src/stackdriver-nozzle/heartbeat/metric_handler.go
+++ b/src/stackdriver-nozzle/heartbeat/metric_handler.go
@@ -76,7 +76,6 @@ func (h *metricHandler) Flush() error {
 		metrics = append(metrics, &messages.Metric{
 			Name:      "heartbeat." + k,
 			Value:     float64(v),
-			Labels:    labels,
 			EventTime: t,
 		})
 	}

--- a/src/stackdriver-nozzle/heartbeat/metric_handler.go
+++ b/src/stackdriver-nozzle/heartbeat/metric_handler.go
@@ -65,19 +65,21 @@ func (h *metricHandler) Flush() error {
 	h.counterMu.Lock()
 	defer h.counterMu.Unlock()
 
-	metrics := []messages.Metric{}
+	metrics := []*messages.Metric{}
 	t := time.Now()
+	labels := map[string]string{
+		"instance": h.nozzleName,
+		"zone":     h.nozzleZone,
+	}
+
 	for k, v := range h.counter {
-		metrics = append(metrics, messages.Metric{
-			Name:  "heartbeat." + k,
-			Value: float64(v),
-			Labels: map[string]string{
-				"instance": h.nozzleName,
-				"zone":     h.nozzleZone,
-			},
+		metrics = append(metrics, &messages.Metric{
+			Name:      "heartbeat." + k,
+			Value:     float64(v),
+			Labels:    labels,
 			EventTime: t,
 		})
 	}
 	h.counter = map[string]uint{}
-	return h.ma.PostMetrics(metrics)
+	return h.ma.PostMetricEvents([]*messages.MetricEvent{{Labels: labels, Metrics: metrics}})
 }

--- a/src/stackdriver-nozzle/messages/metric.go
+++ b/src/stackdriver-nozzle/messages/metric.go
@@ -20,7 +20,7 @@ type Metric struct {
 type MetricEvent struct {
 	Labels  map[string]string
 	Metrics []*Metric
-	Type    events.Envelope_EventType
+	Type    events.Envelope_EventType `json:"-"`
 }
 
 func (m *MetricEvent) Hash() string {

--- a/src/stackdriver-nozzle/messages/metric.go
+++ b/src/stackdriver-nozzle/messages/metric.go
@@ -11,7 +11,6 @@ import (
 type Metric struct {
 	Name      string
 	Value     float64
-	Labels    map[string]string
 	EventTime time.Time
 	Unit      string // TODO Should this be "1" if it's empty?
 }
@@ -26,23 +25,6 @@ type MetricEvent struct {
 
 func (m *MetricEvent) Hash() string {
 	var b bytes.Buffer
-
-	// Extract keys to a slice and sort it
-	keys := make([]string, len(m.Labels), len(m.Labels))
-	for k, _ := range m.Labels {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	for _, k := range keys {
-		b.Write([]byte(k))
-		b.Write([]byte(m.Labels[k]))
-	}
-	return b.String()
-}
-
-func (m *Metric) Hash() string {
-	var b bytes.Buffer
-	b.Write([]byte(m.Name))
 
 	// Extract keys to a slice and sort it
 	keys := make([]string, len(m.Labels), len(m.Labels))

--- a/src/stackdriver-nozzle/messages/metric.go
+++ b/src/stackdriver-nozzle/messages/metric.go
@@ -10,11 +10,34 @@ import (
 
 type Metric struct {
 	Name      string
-	Type      events.Envelope_EventType
 	Value     float64
 	Labels    map[string]string
 	EventTime time.Time
 	Unit      string // TODO Should this be "1" if it's empty?
+}
+
+// MetricEvent represents the translation of an events.Envelope into a set
+// of Metrics
+type MetricEvent struct {
+	Labels  map[string]string
+	Metrics []*Metric
+	Type    events.Envelope_EventType
+}
+
+func (m *MetricEvent) Hash() string {
+	var b bytes.Buffer
+
+	// Extract keys to a slice and sort it
+	keys := make([]string, len(m.Labels), len(m.Labels))
+	for k, _ := range m.Labels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		b.Write([]byte(k))
+		b.Write([]byte(m.Labels[k]))
+	}
+	return b.String()
 }
 
 func (m *Metric) Hash() string {

--- a/src/stackdriver-nozzle/messages/metric.go
+++ b/src/stackdriver-nozzle/messages/metric.go
@@ -18,7 +18,7 @@ type Metric struct {
 // MetricEvent represents the translation of an events.Envelope into a set
 // of Metrics
 type MetricEvent struct {
-	Labels  map[string]string
+	Labels  map[string]string `json:"-"`
 	Metrics []*Metric
 	Type    events.Envelope_EventType `json:"-"`
 }

--- a/src/stackdriver-nozzle/metrics_pipeline/auto_culled_metrics_buffer_test.go
+++ b/src/stackdriver-nozzle/metrics_pipeline/auto_culled_metrics_buffer_test.go
@@ -20,9 +20,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sort"
 	"strconv"
 	"time"
+
+	"sort"
 
 	"github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-nozzle/messages"
 	. "github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-nozzle/metrics_pipeline"
@@ -34,104 +35,139 @@ import (
 var _ = Describe("autoCulledMetricsBuffer", func() {
 	var (
 		metricAdapter *mocks.MetricAdapter
+		heartbeater   *mocks.Heartbeater
 		logger        *mocks.MockLogger
 	)
 
 	BeforeEach(func() {
 		metricAdapter = &mocks.MetricAdapter{}
-
-		// Mock logger
+		heartbeater = mocks.NewHeartbeater()
 		logger = &mocks.MockLogger{}
-
 	})
 
 	It("culls duplicate metrics", func() {
-		d := 100 * time.Millisecond
-		subject, _ := NewAutoCulledMetricsBuffer(context.TODO(), logger, d, 5,
-			metricAdapter)
+		subject, _ := NewAutoCulledMetricsBuffer(context.TODO(), logger, 100*time.Millisecond, 5, metricAdapter, heartbeater)
 
-		subject.PostMetrics([]messages.Metric{
-			{Name: "a", Value: 1},
-			{Name: "b", Value: 2},
-			{Name: "a", Value: 2},
+		subject.PostMetricEvents([]*messages.MetricEvent{
+			{
+				Labels:  map[string]string{"Name": "a"},
+				Metrics: []*messages.Metric{{Name: "a", Value: 1}},
+			},
+			{
+				Labels:  map[string]string{"Name": "a"},
+				Metrics: []*messages.Metric{{Name: "a", Value: 2}, {Name: "b", Value: 2}},
+			},
 		})
-		Eventually(metricAdapter.GetPostedMetrics).Should(HaveLen(2))
+		Eventually(metricAdapter.GetPostedMetricEvents).Should(HaveLen(1))
 
-		expected := []messages.Metric{
-			{Name: "a", Value: 2},
-			{Name: "b", Value: 2},
-		}
-		sort.Sort(sortableMetrics(expected))
-		actual := metricAdapter.GetPostedMetrics()
-		sort.Sort(sortableMetrics(actual))
-		Expect(actual).To(BeEquivalentTo(expected))
+		expected := []*messages.MetricEvent{{
+			Labels:  map[string]string{"Name": "a"},
+			Metrics: []*messages.Metric{{Name: "a", Value: 2}, {Name: "b", Value: 2}},
+		}}
+		postedEvent := metricAdapter.GetPostedMetricEvents()[0]
+		Expect(postedEvent.Metrics).To(HaveLen(2))
+		Expect(postedEvent).To(BeEquivalentTo(expected[0]))
+		Expect(heartbeater.GetCount("metrics.events.sampled")).To(Equal(1))
+	})
 
-		subject.PostMetrics([]messages.Metric{
-			{Name: "c", Value: 1},
-			{Name: "d", Value: 2, Labels: map[string]string{"d1": "a"}},
-			{Name: "d", Value: 2, Labels: map[string]string{"d2": "a"}},
-			{Name: "e", Value: 2, Labels: map[string]string{"a": "a1"}},
-			{Name: "e", Value: 3, Labels: map[string]string{"a": "a1"}},
-			{Name: "e", Value: 3, Labels: map[string]string{"a": "a1"}},
+	It("culls multiple duplicates", func() {
+		subject, _ := NewAutoCulledMetricsBuffer(context.TODO(), logger, 100*time.Millisecond, 5, metricAdapter, heartbeater)
+
+		subject.PostMetricEvents([]*messages.MetricEvent{
+			{
+				Labels:  map[string]string{"d1": "a"},
+				Metrics: []*messages.Metric{{Value: 1}},
+			},
+			{
+				Labels:  map[string]string{"d2": "a"},
+				Metrics: []*messages.Metric{{Value: 2}},
+			},
+			{
+				Labels:  map[string]string{"d3": "a"},
+				Metrics: []*messages.Metric{{Value: 3}},
+			},
+			{
+				Labels:  map[string]string{"d3": "a"},
+				Metrics: []*messages.Metric{{Value: 4}},
+			},
+			{
+				Labels:  map[string]string{"d3": "a"},
+				Metrics: []*messages.Metric{{Value: 5}},
+			},
 		})
 
-		Eventually(metricAdapter.GetPostedMetrics).Should(HaveLen(6))
-
-		expected = []messages.Metric{
-			{Name: "a", Value: 2},
-			{Name: "b", Value: 2},
-			{Name: "c", Value: 1},
-			{Name: "d", Value: 2, Labels: map[string]string{"d1": "a"}},
-			{Name: "d", Value: 2, Labels: map[string]string{"d2": "a"}},
-			{Name: "e", Value: 3, Labels: map[string]string{"a": "a1"}},
+		Eventually(metricAdapter.GetPostedMetricEvents).Should(HaveLen(3))
+		expected := sortableMetrics{
+			{
+				Labels:  map[string]string{"d1": "a"},
+				Metrics: []*messages.Metric{{Value: 1}},
+			},
+			{
+				Labels:  map[string]string{"d2": "a"},
+				Metrics: []*messages.Metric{{Value: 2}},
+			},
+			{
+				Labels:  map[string]string{"d3": "a"},
+				Metrics: []*messages.Metric{{Value: 5}},
+			},
 		}
-		sort.Sort(sortableMetrics(expected))
-		actual = metricAdapter.GetPostedMetrics()
-		sort.Sort(sortableMetrics(actual))
+		actual := sortableMetrics(metricAdapter.GetPostedMetricEvents())
+
+		sort.Sort(expected)
+		sort.Sort(actual)
+
 		Expect(actual).To(BeEquivalentTo(expected))
+		Expect(heartbeater.GetCount("metrics.events.sampled")).To(Equal(2))
 	})
 
 	It("it buffers metrics for the expected duration before flushing", func() {
 		d := 500 * time.Millisecond
-		subject, _ := NewAutoCulledMetricsBuffer(context.TODO(), logger, d, 5,
-			metricAdapter)
+		subject, _ := NewAutoCulledMetricsBuffer(context.TODO(), logger, d, 5, metricAdapter, heartbeater)
 
-		subject.PostMetrics([]messages.Metric{
-			{Name: "a", Value: 1},
-			{Name: "b", Value: 2},
-			{Name: "a", Value: 2},
+		subject.PostMetricEvents([]*messages.MetricEvent{
+			{
+				Labels:  map[string]string{"Name": "a"},
+				Metrics: []*messages.Metric{{Value: 1}},
+			},
+			{
+				Labels:  map[string]string{"Name": "b"},
+				Metrics: []*messages.Metric{{Value: 2}},
+			},
 		})
-		Expect(metricAdapter.GetPostedMetrics()).Should(HaveLen(0))
-		Eventually(metricAdapter.GetPostedMetrics).Should(HaveLen(2))
+		Expect(metricAdapter.GetPostedMetricEvents()).Should(HaveLen(0))
+		Eventually(metricAdapter.GetPostedMetricEvents).Should(HaveLen(2))
 	})
 
 	It("it flushes metrics when the context is canceled", func() {
 		d := 500 * time.Second
 		ctx, cancel := context.WithCancel(context.Background())
-		subject, _ := NewAutoCulledMetricsBuffer(ctx, logger, d, 5,
-			metricAdapter)
+		subject, _ := NewAutoCulledMetricsBuffer(ctx, logger, d, 5, metricAdapter, heartbeater)
 
-		subject.PostMetrics([]messages.Metric{
-			{Name: "a", Value: 1},
-			{Name: "b", Value: 2},
-			{Name: "a", Value: 2},
+		subject.PostMetricEvents([]*messages.MetricEvent{
+			{
+				Labels:  map[string]string{"Name": "a"},
+				Metrics: []*messages.Metric{{Value: 1}},
+			},
+			{
+				Labels:  map[string]string{"Name": "b"},
+				Metrics: []*messages.Metric{{Value: 2}},
+			},
 		})
 		cancel()
-		Eventually(metricAdapter.GetPostedMetrics).Should(HaveLen(2))
+		Eventually(metricAdapter.GetPostedMetricEvents).Should(HaveLen(2))
 	})
 
 	It("it posts the metrics in correct batch size", func() {
 		d := 10 * time.Millisecond
 		batchSize := 200
 
-		metricAdapter.PostMetricsFn = func(metrics []messages.Metric) error {
-			if len(metrics) > batchSize {
-				return fmt.Errorf("Batch size (%v) exceeded max (%v)", len(metrics), batchSize)
+		metricAdapter.PostMetricEventsFn = func(metricEvents []*messages.MetricEvent) error {
+			if len(metricEvents) > batchSize {
+				return fmt.Errorf("Batch size (%v) exceeded max (%v)", len(metricEvents), batchSize)
 			}
-			metricAdapter.Mutex.Lock()
-			defer metricAdapter.Mutex.Unlock()
-			metricAdapter.PostedMetrics = append(metricAdapter.PostedMetrics, metrics...)
-			return metricAdapter.PostMetricError
+
+			metricAdapter.PostedMetricEvents = append(metricAdapter.PostedMetricEvents, metricEvents...)
+			return metricAdapter.PostMetricEventsError
 		}
 
 		metricGroupSizes := []int{199, 200, 201, 399, 400, 1999, 2000, 2001}
@@ -139,33 +175,36 @@ var _ = Describe("autoCulledMetricsBuffer", func() {
 		// Test various numbers of metrics being posted to the buffer
 		for _, groupSize := range metricGroupSizes {
 			ctx, cancel := context.WithCancel(context.Background())
-			metricAdapter.PostedMetrics = []messages.Metric{}
-			metricAdapter.PostMetricError = nil
-			subject, errs := NewAutoCulledMetricsBuffer(ctx, logger, d, batchSize,
-				metricAdapter)
+			metricAdapter.PostedMetricEvents = []*messages.MetricEvent{}
+			metricAdapter.PostMetricEventsError = nil
+			subject, errs := NewAutoCulledMetricsBuffer(ctx, logger, d, batchSize, metricAdapter, heartbeater)
 			for i := 0; i < groupSize; i++ {
-				subject.PostMetrics([]messages.Metric{{Name: strconv.Itoa(i), Value: 1}})
+				subject.PostMetricEvents([]*messages.MetricEvent{
+					{
+						Labels:  map[string]string{"Name": strconv.Itoa(i)},
+						Metrics: []*messages.Metric{{Value: 1}},
+					},
+				})
 			}
 			cancel()
 			err := <-errs
 			Expect(err).ToNot(HaveOccurred())
-			Expect(metricAdapter.PostedMetrics).To(HaveLen(groupSize))
+			Expect(metricAdapter.PostedMetricEvents).To(HaveLen(groupSize))
 		}
 
 	})
 
 	It("sends errors through the error channel", func() {
 		d := 1 * time.Millisecond
-		subject, errs := NewAutoCulledMetricsBuffer(context.TODO(), logger, d, 5,
-			metricAdapter)
+		subject, errs := NewAutoCulledMetricsBuffer(context.TODO(), logger, d, 5, metricAdapter, heartbeater)
 
 		expectedErr := errors.New("fail")
-		metricAdapter.PostMetricError = expectedErr
+		metricAdapter.PostMetricEventsError = expectedErr
 
-		metric := []messages.Metric{{}}
-		subject.PostMetrics(metric)
+		metricEvent := []*messages.MetricEvent{{}}
+		subject.PostMetricEvents(metricEvent)
 
-		Eventually(metricAdapter.GetPostedMetrics).Should(HaveLen(1))
+		Eventually(metricAdapter.GetPostedMetricEvents).Should(HaveLen(1))
 
 		var err error
 		Eventually(errs).Should(Receive(&err))
@@ -180,23 +219,23 @@ var _ = Describe("autoCulledMetricsBuffer", func() {
 
 		BeforeEach(func() {
 			metricPosted = make(chan interface{})
-			metricAdapter.PostMetricsFn = func([]messages.Metric) error {
+			metricAdapter.PostMetricEventsFn = func([]*messages.MetricEvent) error {
 				metricPosted <- struct{}{}
 				time.Sleep(30 * time.Second)
 				return nil
 			}
 
-			subject, _ = NewAutoCulledMetricsBuffer(context.TODO(), logger, 1*time.Millisecond, 5, metricAdapter)
+			subject, _ = NewAutoCulledMetricsBuffer(context.TODO(), logger, 1*time.Millisecond, 5, metricAdapter, heartbeater)
 		})
 
 		It("doesn't block new metrics during flush", func() {
-			metric := []messages.Metric{{}}
-			subject.PostMetrics(metric)
+			metric := []*messages.MetricEvent{{}}
+			subject.PostMetricEvents(metric)
 
 			Eventually(metricPosted).Should(Receive())
 			unblocked := make(chan interface{})
 			go func() {
-				subject.PostMetrics(metric)
+				subject.PostMetricEvents(metric)
 				unblocked <- struct{}{}
 			}()
 			Eventually(unblocked).Should(Receive())
@@ -204,7 +243,7 @@ var _ = Describe("autoCulledMetricsBuffer", func() {
 	})
 })
 
-type sortableMetrics []messages.Metric
+type sortableMetrics []*messages.MetricEvent
 
 func (b sortableMetrics) Len() int {
 	return len(b)

--- a/src/stackdriver-nozzle/metrics_pipeline/router.go
+++ b/src/stackdriver-nozzle/metrics_pipeline/router.go
@@ -31,17 +31,16 @@ func NewRouter(metricAdapter stackdriver.MetricAdapter, metricEvents []events.En
 	return r
 }
 
-func (r *router) PostMetrics(metrics []messages.Metric) error {
-	for _, metric := range metrics {
-		if r.metricEvents[metric.Type] {
-			// TODO: seems strange to re-package this as a new slice
-			r.metricAdapter.PostMetrics([]messages.Metric{metric})
+func (r *router) PostMetricEvents(events []*messages.MetricEvent) error {
+	for _, event := range events {
+		if r.metricEvents[event.Type] {
+			r.metricAdapter.PostMetricEvents([]*messages.MetricEvent{event})
 		}
 
-		if r.logEvents[metric.Type] {
+		if r.logEvents[event.Type] {
 			log := &messages.Log{
-				Labels:  metric.Labels,
-				Payload: metric,
+				Labels:  event.Labels,
+				Payload: event,
 			}
 			r.logAdapter.PostLog(log)
 		}

--- a/src/stackdriver-nozzle/metrics_pipeline/router_test.go
+++ b/src/stackdriver-nozzle/metrics_pipeline/router_test.go
@@ -61,7 +61,6 @@ var _ = Describe("Router", func() {
 		logEvent := events.Envelope_ValueMetric
 		labels := map[string]string{"foo": "bar"}
 		metric := &messages.Metric{
-			Labels:    labels,
 			Name:      "valueMetric",
 			Value:     float64(123),
 			EventTime: time.Now(),
@@ -72,7 +71,7 @@ var _ = Describe("Router", func() {
 		router.PostMetricEvents([]*messages.MetricEvent{metricEvent})
 		Expect(logAdapter.PostedLogs).To(HaveLen(1))
 		log := logAdapter.PostedLogs[0]
-		Expect(log.Labels).To(Equal(metric.Labels))
+		Expect(log.Labels).To(Equal(labels))
 		Expect(log.Payload).To(BeAssignableToTypeOf(&messages.MetricEvent{}))
 		payload := log.Payload.(*messages.MetricEvent)
 		Expect(payload.Metrics).To(Equal([]*messages.Metric{metric}))

--- a/src/stackdriver-nozzle/metrics_pipeline/router_test.go
+++ b/src/stackdriver-nozzle/metrics_pipeline/router_test.go
@@ -25,16 +25,16 @@ var _ = Describe("Router", func() {
 		logEvent := events.Envelope_ValueMetric
 
 		router := NewRouter(metricAdapter, []events.Envelope_EventType{metricEvent}, logAdapter, []events.Envelope_EventType{logEvent})
-		err := router.PostMetrics([]messages.Metric{
+		err := router.PostMetricEvents([]*messages.MetricEvent{
 			{Type: metricEvent},
 			{Type: logEvent},
 		})
 
 		Expect(err).NotTo(HaveOccurred())
-		Expect(metricAdapter.PostedMetrics).To(HaveLen(1))
-		Expect(metricAdapter.PostedMetrics[0].Type).To(Equal(metricEvent))
+		Expect(metricAdapter.PostedMetricEvents).To(HaveLen(1))
+		Expect(metricAdapter.PostedMetricEvents[0].Type).To(Equal(metricEvent))
 		Expect(logAdapter.PostedLogs).To(HaveLen(1))
-		Expect(logAdapter.PostedLogs[0].Payload.(messages.Metric).Type).To(Equal(logEvent))
+		Expect(logAdapter.PostedLogs[0].Payload.(*messages.MetricEvent).Type).To(Equal(logEvent))
 	})
 
 	It("can route an event to two locations", func() {
@@ -43,37 +43,40 @@ var _ = Describe("Router", func() {
 		events := []events.Envelope_EventType{metricEvent, logEvent}
 
 		router := NewRouter(metricAdapter, events, logAdapter, events)
-		err := router.PostMetrics([]messages.Metric{
+		err := router.PostMetricEvents([]*messages.MetricEvent{
 			{Type: metricEvent},
 			{Type: logEvent},
 		})
 
 		Expect(err).NotTo(HaveOccurred())
-		Expect(metricAdapter.PostedMetrics).To(HaveLen(2))
-		Expect(metricAdapter.PostedMetrics[0].Type).To(Equal(metricEvent))
-		Expect(metricAdapter.PostedMetrics[1].Type).To(Equal(logEvent))
+		Expect(metricAdapter.PostedMetricEvents).To(HaveLen(2))
+		Expect(metricAdapter.PostedMetricEvents[0].Type).To(Equal(metricEvent))
+		Expect(metricAdapter.PostedMetricEvents[1].Type).To(Equal(logEvent))
 		Expect(logAdapter.PostedLogs).To(HaveLen(2))
-		Expect(logAdapter.PostedLogs[0].Payload.(messages.Metric).Type).To(Equal(metricEvent))
-		Expect(logAdapter.PostedLogs[1].Payload.(messages.Metric).Type).To(Equal(logEvent))
+		Expect(logAdapter.PostedLogs[0].Payload.(*messages.MetricEvent).Type).To(Equal(metricEvent))
+		Expect(logAdapter.PostedLogs[1].Payload.(*messages.MetricEvent).Type).To(Equal(logEvent))
 	})
 
 	It("can translate Metric statements to Logs", func() {
 		logEvent := events.Envelope_ValueMetric
-		metric := messages.Metric{
-			Labels:    map[string]string{"foo": "bar"},
-			Type:      logEvent,
+		labels := map[string]string{"foo": "bar"}
+		metric := &messages.Metric{
+			Labels:    labels,
 			Name:      "valueMetric",
 			Value:     float64(123),
 			EventTime: time.Now(),
 			Unit:      "f",
 		}
+		metricEvent := &messages.MetricEvent{Type: logEvent, Labels: labels, Metrics: []*messages.Metric{metric}}
 		router := NewRouter(nil, nil, logAdapter, []events.Envelope_EventType{logEvent})
-		router.PostMetrics([]messages.Metric{metric})
+		router.PostMetricEvents([]*messages.MetricEvent{metricEvent})
 		Expect(logAdapter.PostedLogs).To(HaveLen(1))
 		log := logAdapter.PostedLogs[0]
 		Expect(log.Labels).To(Equal(metric.Labels))
-		Expect(log.Payload).To(BeAssignableToTypeOf(messages.Metric{}))
-		payload := log.Payload.(messages.Metric)
-		Expect(payload).To(Equal(metric))
+		Expect(log.Payload).To(BeAssignableToTypeOf(&messages.MetricEvent{}))
+		payload := log.Payload.(*messages.MetricEvent)
+		Expect(payload.Metrics).To(Equal([]*messages.Metric{metric}))
+		Expect(payload.Type).To(Equal(logEvent))
+		Expect(payload.Labels).To(Equal(labels))
 	})
 })

--- a/src/stackdriver-nozzle/mocks/metric_adapter.go
+++ b/src/stackdriver-nozzle/mocks/metric_adapter.go
@@ -23,26 +23,28 @@ import (
 )
 
 type MetricAdapter struct {
-	PostMetricsFn   func(metrics []messages.Metric) error
-	PostMetricError error
-	PostedMetrics   []messages.Metric
-	Mutex           sync.Mutex
+	sync.Mutex
+
+	PostMetricEventsFn    func(metrics []*messages.MetricEvent) error
+	PostMetricEventsError error
+	PostedMetricEvents    []*messages.MetricEvent
 }
 
-func (m *MetricAdapter) PostMetrics(metrics []messages.Metric) error {
-	if m.PostMetricsFn != nil {
-		return m.PostMetricsFn(metrics)
+func (m *MetricAdapter) PostMetricEvents(events []*messages.MetricEvent) error {
+	m.Lock()
+	defer m.Unlock()
+
+	if m.PostMetricEventsFn != nil {
+		return m.PostMetricEventsFn(events)
 	}
 
-	m.Mutex.Lock()
-	defer m.Mutex.Unlock()
-	m.PostedMetrics = append(m.PostedMetrics, metrics...)
-	return m.PostMetricError
+	m.PostedMetricEvents = append(m.PostedMetricEvents, events...)
+	return m.PostMetricEventsError
 }
 
-func (m *MetricAdapter) GetPostedMetrics() []messages.Metric {
-	m.Mutex.Lock()
-	defer m.Mutex.Unlock()
+func (m *MetricAdapter) GetPostedMetricEvents() []*messages.MetricEvent {
+	m.Lock()
+	defer m.Unlock()
 
-	return m.PostedMetrics
+	return m.PostedMetricEvents
 }

--- a/src/stackdriver-nozzle/mocks/metrics_buffer.go
+++ b/src/stackdriver-nozzle/mocks/metrics_buffer.go
@@ -22,12 +22,13 @@ type MetricsBuffer struct {
 	PostedMetrics []messages.Metric
 }
 
-func (m *MetricsBuffer) PostMetric(metric *messages.Metric) {
-	m.PostedMetrics = append(m.PostedMetrics, *metric)
-}
+func (m *MetricsBuffer) PostMetricEvents(events []*messages.MetricEvent) error {
+	for _, event := range events {
+		for _, metric := range event.Metrics {
+			m.PostedMetrics = append(m.PostedMetrics, *metric)
+		}
+	}
 
-func (m *MetricsBuffer) PostMetrics(metrics []messages.Metric) error {
-	m.PostedMetrics = append(m.PostedMetrics, metrics...)
 	return nil
 }
 

--- a/src/stackdriver-nozzle/nozzle/metric_sink.go
+++ b/src/stackdriver-nozzle/nozzle/metric_sink.go
@@ -56,19 +56,18 @@ func (ms *metricSink) Receive(envelope *events.Envelope) error {
 		metrics = []*messages.Metric{{
 			Name:      valueMetric.GetName(),
 			Value:     valueMetric.GetValue(),
-			Labels:    labels,
 			EventTime: eventTime,
 			Unit:      ms.unitParser.Parse(valueMetric.GetUnit()),
 		}}
 	case events.Envelope_ContainerMetric:
 		containerMetric := envelope.GetContainerMetric()
 		metrics = []*messages.Metric{
-			{Name: "diskBytesQuota", Value: float64(containerMetric.GetDiskBytesQuota()), EventTime: eventTime, Labels: labels},
-			{Name: "instanceIndex", Value: float64(containerMetric.GetInstanceIndex()), EventTime: eventTime, Labels: labels},
-			{Name: "cpuPercentage", Value: float64(containerMetric.GetCpuPercentage()), EventTime: eventTime, Labels: labels},
-			{Name: "diskBytes", Value: float64(containerMetric.GetDiskBytes()), EventTime: eventTime, Labels: labels},
-			{Name: "memoryBytes", Value: float64(containerMetric.GetMemoryBytes()), EventTime: eventTime, Labels: labels},
-			{Name: "memoryBytesQuota", Value: float64(containerMetric.GetMemoryBytesQuota()), EventTime: eventTime, Labels: labels},
+			{Name: "diskBytesQuota", Value: float64(containerMetric.GetDiskBytesQuota()), EventTime: eventTime},
+			{Name: "instanceIndex", Value: float64(containerMetric.GetInstanceIndex()), EventTime: eventTime},
+			{Name: "cpuPercentage", Value: float64(containerMetric.GetCpuPercentage()), EventTime: eventTime},
+			{Name: "diskBytes", Value: float64(containerMetric.GetDiskBytes()), EventTime: eventTime},
+			{Name: "memoryBytes", Value: float64(containerMetric.GetMemoryBytes()), EventTime: eventTime},
+			{Name: "memoryBytesQuota", Value: float64(containerMetric.GetMemoryBytesQuota()), EventTime: eventTime},
 		}
 	case events.Envelope_CounterEvent:
 		counterEvent := envelope.GetCounterEvent()
@@ -77,13 +76,11 @@ func (ms *metricSink) Receive(envelope *events.Envelope) error {
 				Name:      fmt.Sprintf("%v.delta", counterEvent.GetName()),
 				Value:     float64(counterEvent.GetDelta()),
 				EventTime: eventTime,
-				Labels:    labels,
 			},
 			{
 				Name:      fmt.Sprintf("%v.total", counterEvent.GetName()),
 				Value:     float64(counterEvent.GetTotal()),
 				EventTime: eventTime,
-				Labels:    labels,
 			},
 		}
 	default:

--- a/src/stackdriver-nozzle/nozzle/metric_sink.go
+++ b/src/stackdriver-nozzle/nozzle/metric_sink.go
@@ -49,13 +49,12 @@ func (ms *metricSink) Receive(envelope *events.Envelope) error {
 		int64(timestamp%time.Second),
 	)
 
-	var metrics []messages.Metric
+	var metrics []*messages.Metric
 	switch envelope.GetEventType() {
 	case events.Envelope_ValueMetric:
 		valueMetric := envelope.GetValueMetric()
-		metrics = []messages.Metric{{
+		metrics = []*messages.Metric{{
 			Name:      valueMetric.GetName(),
-			Type:      envelope.GetEventType(),
 			Value:     valueMetric.GetValue(),
 			Labels:    labels,
 			EventTime: eventTime,
@@ -63,27 +62,25 @@ func (ms *metricSink) Receive(envelope *events.Envelope) error {
 		}}
 	case events.Envelope_ContainerMetric:
 		containerMetric := envelope.GetContainerMetric()
-		metrics = []messages.Metric{
-			{Name: "diskBytesQuota", Type: envelope.GetEventType(), Value: float64(containerMetric.GetDiskBytesQuota()), EventTime: eventTime, Labels: labels},
-			{Name: "instanceIndex", Type: envelope.GetEventType(), Value: float64(containerMetric.GetInstanceIndex()), EventTime: eventTime, Labels: labels},
-			{Name: "cpuPercentage", Type: envelope.GetEventType(), Value: float64(containerMetric.GetCpuPercentage()), EventTime: eventTime, Labels: labels},
-			{Name: "diskBytes", Type: envelope.GetEventType(), Value: float64(containerMetric.GetDiskBytes()), EventTime: eventTime, Labels: labels},
-			{Name: "memoryBytes", Type: envelope.GetEventType(), Value: float64(containerMetric.GetMemoryBytes()), EventTime: eventTime, Labels: labels},
-			{Name: "memoryBytesQuota", Type: envelope.GetEventType(), Value: float64(containerMetric.GetMemoryBytesQuota()), EventTime: eventTime, Labels: labels},
+		metrics = []*messages.Metric{
+			{Name: "diskBytesQuota", Value: float64(containerMetric.GetDiskBytesQuota()), EventTime: eventTime, Labels: labels},
+			{Name: "instanceIndex", Value: float64(containerMetric.GetInstanceIndex()), EventTime: eventTime, Labels: labels},
+			{Name: "cpuPercentage", Value: float64(containerMetric.GetCpuPercentage()), EventTime: eventTime, Labels: labels},
+			{Name: "diskBytes", Value: float64(containerMetric.GetDiskBytes()), EventTime: eventTime, Labels: labels},
+			{Name: "memoryBytes", Value: float64(containerMetric.GetMemoryBytes()), EventTime: eventTime, Labels: labels},
+			{Name: "memoryBytesQuota", Value: float64(containerMetric.GetMemoryBytesQuota()), EventTime: eventTime, Labels: labels},
 		}
 	case events.Envelope_CounterEvent:
 		counterEvent := envelope.GetCounterEvent()
-		metrics = []messages.Metric{
+		metrics = []*messages.Metric{
 			{
 				Name:      fmt.Sprintf("%v.delta", counterEvent.GetName()),
-				Type:      envelope.GetEventType(),
 				Value:     float64(counterEvent.GetDelta()),
 				EventTime: eventTime,
 				Labels:    labels,
 			},
 			{
 				Name:      fmt.Sprintf("%v.total", counterEvent.GetName()),
-				Type:      envelope.GetEventType(),
 				Value:     float64(counterEvent.GetTotal()),
 				EventTime: eventTime,
 				Labels:    labels,
@@ -93,5 +90,7 @@ func (ms *metricSink) Receive(envelope *events.Envelope) error {
 		return fmt.Errorf("unknown event type: %v", envelope.EventType)
 	}
 
-	return ms.metricAdapter.PostMetrics(metrics)
+	return ms.metricAdapter.PostMetricEvents([]*messages.MetricEvent{
+		{Metrics: metrics, Labels: labels, Type: envelope.GetEventType()},
+	})
 }

--- a/src/stackdriver-nozzle/nozzle/metric_sink_test.go
+++ b/src/stackdriver-nozzle/nozzle/metric_sink_test.go
@@ -82,7 +82,6 @@ var _ = Describe("MetricSink", func() {
 		Expect(metrics[0]).To(MatchAllFields(Fields{
 			"Name":      Equal("valueMetricName"),
 			"Value":     Equal(123.456),
-			"Labels":    Equal(labels),
 			"EventTime": Ignore(),
 			"Unit":      Equal("{foo}"),
 		}))
@@ -131,12 +130,12 @@ var _ = Describe("MetricSink", func() {
 		}
 
 		Expect(metrics).To(MatchAllElements(eventName, Elements{
-			"diskBytesQuota":   MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(1073741824)), "Labels": Equal(labels), "EventTime": Ignore(), "Unit": Equal("")}),
-			"instanceIndex":    MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(0)), "Labels": Equal(labels), "EventTime": Ignore(), "Unit": Equal("")}),
-			"cpuPercentage":    MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(0.061651273460637)), "Labels": Equal(labels), "EventTime": Ignore(), "Unit": Equal("")}),
-			"diskBytes":        MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(164634624)), "Labels": Equal(labels), "EventTime": Ignore(), "Unit": Equal("")}),
-			"memoryBytes":      MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(16601088)), "Labels": Equal(labels), "EventTime": Ignore(), "Unit": Equal("")}),
-			"memoryBytesQuota": MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(33554432)), "Labels": Equal(labels), "EventTime": Ignore(), "Unit": Equal("")}),
+			"diskBytesQuota":   MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(1073741824)), "EventTime": Ignore(), "Unit": Equal("")}),
+			"instanceIndex":    MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(0)), "EventTime": Ignore(), "Unit": Equal("")}),
+			"cpuPercentage":    MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(0.061651273460637)), "EventTime": Ignore(), "Unit": Equal("")}),
+			"diskBytes":        MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(164634624)), "EventTime": Ignore(), "Unit": Equal("")}),
+			"memoryBytes":      MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(16601088)), "EventTime": Ignore(), "Unit": Equal("")}),
+			"memoryBytesQuota": MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(33554432)), "EventTime": Ignore(), "Unit": Equal("")}),
 		}))
 	})
 
@@ -172,14 +171,12 @@ var _ = Describe("MetricSink", func() {
 			"counterName.delta": MatchAllFields(Fields{
 				"Name":      Ignore(),
 				"Value":     Equal(float64(654321)),
-				"Labels":    Equal(labels),
 				"EventTime": Ignore(),
 				"Unit":      Equal(""),
 			}),
 			"counterName.total": MatchAllFields(Fields{
 				"Name":      Ignore(),
 				"Value":     Equal(float64(123456)),
-				"Labels":    Equal(labels),
 				"EventTime": Ignore(),
 				"Unit":      Equal(""),
 			}),

--- a/src/stackdriver-nozzle/nozzle/metric_sink_test.go
+++ b/src/stackdriver-nozzle/nozzle/metric_sink_test.go
@@ -81,7 +81,6 @@ var _ = Describe("MetricSink", func() {
 		Expect(metrics).To(HaveLen(1))
 		Expect(metrics[0]).To(MatchAllFields(Fields{
 			"Name":      Equal("valueMetricName"),
-			"Type":      Equal(events.Envelope_ValueMetric),
 			"Value":     Equal(123.456),
 			"Labels":    Equal(labels),
 			"EventTime": Ignore(),
@@ -132,12 +131,12 @@ var _ = Describe("MetricSink", func() {
 		}
 
 		Expect(metrics).To(MatchAllElements(eventName, Elements{
-			"diskBytesQuota":   MatchAllFields(Fields{"Name": Ignore(), "Type": Equal(events.Envelope_ContainerMetric), "Value": Equal(float64(1073741824)), "Labels": Equal(labels), "EventTime": Ignore(), "Unit": Equal("")}),
-			"instanceIndex":    MatchAllFields(Fields{"Name": Ignore(), "Type": Equal(events.Envelope_ContainerMetric), "Value": Equal(float64(0)), "Labels": Equal(labels), "EventTime": Ignore(), "Unit": Equal("")}),
-			"cpuPercentage":    MatchAllFields(Fields{"Name": Ignore(), "Type": Equal(events.Envelope_ContainerMetric), "Value": Equal(float64(0.061651273460637)), "Labels": Equal(labels), "EventTime": Ignore(), "Unit": Equal("")}),
-			"diskBytes":        MatchAllFields(Fields{"Name": Ignore(), "Type": Equal(events.Envelope_ContainerMetric), "Value": Equal(float64(164634624)), "Labels": Equal(labels), "EventTime": Ignore(), "Unit": Equal("")}),
-			"memoryBytes":      MatchAllFields(Fields{"Name": Ignore(), "Type": Equal(events.Envelope_ContainerMetric), "Value": Equal(float64(16601088)), "Labels": Equal(labels), "EventTime": Ignore(), "Unit": Equal("")}),
-			"memoryBytesQuota": MatchAllFields(Fields{"Name": Ignore(), "Type": Equal(events.Envelope_ContainerMetric), "Value": Equal(float64(33554432)), "Labels": Equal(labels), "EventTime": Ignore(), "Unit": Equal("")}),
+			"diskBytesQuota":   MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(1073741824)), "Labels": Equal(labels), "EventTime": Ignore(), "Unit": Equal("")}),
+			"instanceIndex":    MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(0)), "Labels": Equal(labels), "EventTime": Ignore(), "Unit": Equal("")}),
+			"cpuPercentage":    MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(0.061651273460637)), "Labels": Equal(labels), "EventTime": Ignore(), "Unit": Equal("")}),
+			"diskBytes":        MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(164634624)), "Labels": Equal(labels), "EventTime": Ignore(), "Unit": Equal("")}),
+			"memoryBytes":      MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(16601088)), "Labels": Equal(labels), "EventTime": Ignore(), "Unit": Equal("")}),
+			"memoryBytesQuota": MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(33554432)), "Labels": Equal(labels), "EventTime": Ignore(), "Unit": Equal("")}),
 		}))
 	})
 
@@ -172,7 +171,6 @@ var _ = Describe("MetricSink", func() {
 		Expect(metrics).To(MatchAllElements(eventName, Elements{
 			"counterName.delta": MatchAllFields(Fields{
 				"Name":      Ignore(),
-				"Type":      Equal(events.Envelope_CounterEvent),
 				"Value":     Equal(float64(654321)),
 				"Labels":    Equal(labels),
 				"EventTime": Ignore(),
@@ -180,7 +178,6 @@ var _ = Describe("MetricSink", func() {
 			}),
 			"counterName.total": MatchAllFields(Fields{
 				"Name":      Ignore(),
-				"Type":      Equal(events.Envelope_CounterEvent),
 				"Value":     Equal(float64(123456)),
 				"Labels":    Equal(labels),
 				"EventTime": Ignore(),

--- a/src/stackdriver-nozzle/stackdriver/metric_adapter.go
+++ b/src/stackdriver-nozzle/stackdriver/metric_adapter.go
@@ -31,7 +31,7 @@ import (
 )
 
 type MetricAdapter interface {
-	PostMetrics([]messages.Metric) error
+	PostMetricEvents([]*messages.MetricEvent) error
 }
 
 type Heartbeater interface {
@@ -62,48 +62,50 @@ func NewMetricAdapter(projectID string, client MetricClient, heartbeater Heartbe
 	return ma, err
 }
 
-func (ma *metricAdapter) PostMetrics(metrics []messages.Metric) error {
-	if len(metrics) == 0 {
-		return nil
-	}
+func (ma *metricAdapter) PostMetricEvents(events []*messages.MetricEvent) (err error) {
+	for _, event := range events {
+		if len(event.Metrics) == 0 {
+			return nil
+		}
 
-	projectName := path.Join("projects", ma.projectID)
-	var timeSerieses []*monitoringpb.TimeSeries
+		projectName := path.Join("projects", ma.projectID)
+		var timeSerieses []*monitoringpb.TimeSeries
+		ma.heartbeater.Increment("metrics.events.count")
 
-	for _, metric := range metrics {
-		ma.heartbeater.Increment("metrics.count")
+		for _, metric := range event.Metrics {
+			ma.heartbeater.Increment("metrics.count")
+			err := ma.ensureMetricDescriptor(metric)
+			if err != nil {
+				return err
+			}
 
-		err := ma.ensureMetricDescriptor(metric)
+			metricType := path.Join("custom.googleapis.com", metric.Name)
+			timeSeries := monitoringpb.TimeSeries{
+				Metric: &metricpb.Metric{
+					Type:   metricType,
+					Labels: metric.Labels,
+				},
+				Points: points(metric.Value, metric.EventTime),
+			}
+			timeSerieses = append(timeSerieses, &timeSeries)
+		}
+
+		request := &monitoringpb.CreateTimeSeriesRequest{
+			Name:       projectName,
+			TimeSeries: timeSerieses,
+		}
+
+		ma.heartbeater.Increment("metrics.requests")
+		err = ma.client.Post(request)
 		if err != nil {
-			return err
+			ma.heartbeater.Increment("metrics.errors")
 		}
-
-		metricType := path.Join("custom.googleapis.com", metric.Name)
-		timeSeries := monitoringpb.TimeSeries{
-			Metric: &metricpb.Metric{
-				Type:   metricType,
-				Labels: metric.Labels,
-			},
-			Points: points(metric.Value, metric.EventTime),
-		}
-		timeSerieses = append(timeSerieses, &timeSeries)
+		err = errors.Wrapf(err, "Request: %+v", request)
 	}
-
-	request := &monitoringpb.CreateTimeSeriesRequest{
-		Name:       projectName,
-		TimeSeries: timeSerieses,
-	}
-
-	ma.heartbeater.Increment("metrics.requests")
-	err := ma.client.Post(request)
-	if err != nil {
-		ma.heartbeater.Increment("metrics.errors")
-	}
-	err = errors.Wrapf(err, "Request: %+v", request)
-	return err
+	return
 }
 
-func (ma *metricAdapter) CreateMetricDescriptor(metric messages.Metric) error {
+func (ma *metricAdapter) CreateMetricDescriptor(metric *messages.Metric) error {
 	projectName := path.Join("projects", ma.projectID)
 	metricType := path.Join("custom.googleapis.com", metric.Name)
 	metricName := path.Join(projectName, "metricDescriptors", metricType)
@@ -150,7 +152,7 @@ func (ma *metricAdapter) fetchMetricDescriptorNames() error {
 	return nil
 }
 
-func (ma *metricAdapter) ensureMetricDescriptor(metric messages.Metric) error {
+func (ma *metricAdapter) ensureMetricDescriptor(metric *messages.Metric) error {
 	if metric.Unit == "" {
 		return nil
 	}

--- a/src/stackdriver-nozzle/stackdriver/metric_adapter_test.go
+++ b/src/stackdriver-nozzle/stackdriver/metric_adapter_test.go
@@ -50,23 +50,21 @@ var _ = Describe("MetricAdapter", func() {
 
 		metrics := []*messages.Metric{
 			{
-				Name:  "metricName",
-				Value: 123.45,
-				Labels: map[string]string{
-					"key": "name",
-				},
+				Name:      "metricName",
+				Value:     123.45,
 				EventTime: eventTime,
 			},
 			{
-				Name:  "secondMetricName",
-				Value: 54.321,
-				Labels: map[string]string{
-					"secondKey": "secondName",
-				},
+				Name:      "secondMetricName",
+				Value:     54.321,
 				EventTime: eventTime,
 			},
 		}
-		metricEvents := []*messages.MetricEvent{{Metrics: metrics}}
+		labels := map[string]string{
+			"key": "name",
+		}
+
+		metricEvents := []*messages.MetricEvent{{Labels: labels, Metrics: metrics}}
 
 		subject.PostMetricEvents(metricEvents)
 
@@ -80,7 +78,7 @@ var _ = Describe("MetricAdapter", func() {
 
 		timeSeries := timeSerieses[0]
 		Expect(timeSeries.GetMetric().Type).To(Equal("custom.googleapis.com/metricName"))
-		Expect(timeSeries.GetMetric().Labels).To(Equal(metrics[0].Labels))
+		Expect(timeSeries.GetMetric().Labels).To(Equal(labels))
 		Expect(timeSeries.GetPoints()).To(HaveLen(1))
 
 		point := timeSeries.GetPoints()[0]
@@ -92,7 +90,7 @@ var _ = Describe("MetricAdapter", func() {
 
 		timeSeries = timeSerieses[1]
 		Expect(timeSeries.GetMetric().Type).To(Equal("custom.googleapis.com/secondMetricName"))
-		Expect(timeSeries.GetMetric().Labels).To(Equal(metrics[1].Labels))
+		Expect(timeSeries.GetMetric().Labels).To(Equal(labels))
 		Expect(timeSeries.GetPoints()).To(HaveLen(1))
 
 		point = timeSeries.GetPoints()[0]
@@ -102,18 +100,18 @@ var _ = Describe("MetricAdapter", func() {
 	})
 
 	It("creates metric descriptors", func() {
+		labels := map[string]string{"key": "value"}
+
 		metrics := []*messages.Metric{
 			{
-				Name:   "metricWithUnit",
-				Labels: map[string]string{"key": "value"},
-				Unit:   "{foobar}",
+				Name: "metricWithUnit",
+				Unit: "{foobar}",
 			},
 			{
-				Name:   "metricWithoutUnit",
-				Labels: map[string]string{"key": "value"},
+				Name: "metricWithoutUnit",
 			},
 		}
-		metricEvents := []*messages.MetricEvent{{Metrics: metrics}}
+		metricEvents := []*messages.MetricEvent{{Labels: labels, Metrics: metrics}}
 
 		subject.PostMetricEvents(metricEvents)
 

--- a/src/stackdriver-nozzle/vendor/code.cloudfoundry.org/diodes/LICENSE
+++ b/src/stackdriver-nozzle/vendor/code.cloudfoundry.org/diodes/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/stackdriver-nozzle/vendor/code.cloudfoundry.org/diodes/NOTICE
+++ b/src/stackdriver-nozzle/vendor/code.cloudfoundry.org/diodes/NOTICE
@@ -1,0 +1,18 @@
+Copyright (c) 2017-Present CloudFoundry.org Foundation, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+This project may include a number of subcomponents with separate
+copyright notices and license terms. Your use of these subcomponents
+is subject to the terms and conditions of each subcomponent's license,
+as noted in the LICENSE file.

--- a/src/stackdriver-nozzle/vendor/code.cloudfoundry.org/diodes/README.md
+++ b/src/stackdriver-nozzle/vendor/code.cloudfoundry.org/diodes/README.md
@@ -1,0 +1,93 @@
+# diodes
+
+Diodes are ring buffers manipulated via atomics.
+
+Diodes are optimized for high throughput scenarios where losing data is
+acceptable. Unlike a channel, a diode will overwrite data in lieu of blocking.
+A diode does its best to not "push back" on the producer. In other words,
+invoking `Set()` on a diode never blocks.
+
+### Example
+
+```
+go get code.cloudfoundry.org/diodes
+```
+
+```go
+d := diodes.NewPoller(diodes.NewOneToOne(b.N, diodes.AlertFunc(func(missed int) {
+	log.Printf("Dropped %d messages", missed)
+})))
+
+go func() {
+	for i := 0; i < 1000; i++ {
+		// Warning: Do not use i. By taking the address,
+		// you would not get each value
+		j := i 		d.Set(diodes.GenericDataType(&data))
+		d.Set(diodes.GenericDataType(&j))
+	}
+}()
+
+for {
+	d.Next()
+}
+
+```
+
+### Dropping Data
+
+The diode takes an `Alerter` as an argument to alert the user code to when
+the read noticed it missed data. It is important to note that the go-routine
+consuming from the diode is used to signal the alert.
+
+When the diode notices it has fallen behind, it will move the read index to
+the new write index and therefore drop more than a single message.
+
+There are two things to consider when choosing a diode:
+1. Storage layer
+2. Access layer
+
+### Storage Layer
+
+##### OneToOne
+
+The OneToOne diode is meant to be used by one producing (invoking `Set()`)
+go-routine and a (different) consuming (invoking `TryNext()`) go-routine. It
+is not thread safe for multiple readers or writers.
+
+##### ManyToOne
+
+The ManyToOne diode is optimized for many producing (invoking `Set()`)
+go-routines and a single consuming (invoking `TryNext()`) go-routine. It is
+not thread safe for multiple readers.
+
+It is recommended to have a larger diode buffer size if the number of producers
+is high. This is to avoid the diode from having to mitigate write collisions
+(it will call its alert function if this occurs).
+
+### Access Layer
+
+##### Poller
+
+The Poller uses polling via `time.Sleep(...)` when `Next()` is invoked. While
+polling might seem sub-optimal, it allows the producer to be completely
+decoupled from the consumer. If you require very minimal push back on the
+producer, then the Poller is a better choice. However, if you require several
+diodes (e.g. one per connected client), then having several go-routines
+polling (sleeping) may be hard on the scheduler.
+
+##### Waiter
+
+The Waiter uses a conditional mutex to manage when the reader is alerted
+of new data. While this method is great for the scheduler, it does have
+extra overhead for the producer. Therefore, it is better suited for situations
+where you have several diodes and can afford slightly slower producers.
+
+
+### Benchmarks
+
+There are benchmarks that compare the various storage and access layers to
+channels. To run them:
+
+```
+go test -bench=. -run=NoTest
+```

--- a/src/stackdriver-nozzle/vendor/code.cloudfoundry.org/diodes/many_to_one.go
+++ b/src/stackdriver-nozzle/vendor/code.cloudfoundry.org/diodes/many_to_one.go
@@ -1,0 +1,124 @@
+package diodes
+
+import (
+	"log"
+	"sync/atomic"
+	"unsafe"
+)
+
+// ManyToOne diode is optimal for many writers (go-routines B-n) and a single
+// reader (go-routine A). It is not thread safe for multiple readers.
+type ManyToOne struct {
+	buffer     []unsafe.Pointer
+	writeIndex uint64
+	readIndex  uint64
+	alerter    Alerter
+}
+
+// NewManyToOne creates a new diode (ring buffer). The ManyToOne diode
+// is optimzed for many writers (on go-routines B-n) and a single reader
+// (on go-routine A).
+func NewManyToOne(size int, alerter Alerter) *ManyToOne {
+	d := &ManyToOne{
+		buffer:  make([]unsafe.Pointer, size),
+		alerter: alerter,
+	}
+
+	// Start write index at the value before 0
+	// to allow the first write to use AddUint64
+	// and still have a beginning index of 0
+	d.writeIndex = ^d.writeIndex
+	return d
+}
+
+// Set sets the data in the next slot of the ring buffer.
+func (d *ManyToOne) Set(data GenericDataType) {
+	for {
+		writeIndex := atomic.AddUint64(&d.writeIndex, 1)
+		idx := writeIndex % uint64(len(d.buffer))
+		old := atomic.LoadPointer(&d.buffer[idx])
+
+		if old != nil &&
+			(*bucket)(old) != nil &&
+			(*bucket)(old).seq > writeIndex-uint64(len(d.buffer)) {
+			log.Println("Diode set collision: consider using a larger diode")
+			continue
+		}
+
+		newBucket := &bucket{
+			data: data,
+			seq:  writeIndex,
+		}
+
+		if !atomic.CompareAndSwapPointer(&d.buffer[idx], old, unsafe.Pointer(newBucket)) {
+			log.Println("Diode set collision: consider using a larger diode")
+			continue
+		}
+
+		return
+	}
+}
+
+// TryNext will attempt to read from the next slot of the ring buffer.
+// If there is not data available, it will return (nil, false).
+func (d *ManyToOne) TryNext() (data GenericDataType, ok bool) {
+	// Read a value from the ring buffer based on the readIndex.
+	idx := d.readIndex % uint64(len(d.buffer))
+	result := (*bucket)(atomic.SwapPointer(&d.buffer[idx], nil))
+
+	// When the result is nil that means the writer has not had the
+	// opportunity to write a value into the diode. This value must be ignored
+	// and the read head must not increment.
+	if result == nil {
+		return nil, false
+	}
+
+	// When the seq value is less than the current read index that means a
+	// value was read from idx that was previously written but has since has
+	// been dropped. This value must be ignored and the read head must not
+	// increment.
+	//
+	// The simulation for this scenario assumes the fast forward occurred as
+	// detailed below.
+	//
+	// 5. The reader reads again getting seq 5. It then reads again expecting
+	//    seq 6 but gets seq 2. This is a read of a stale value that was
+	//    effectively "dropped" so the read fails and the read head stays put.
+	//    `| 4 | 5 | 2 | 3 |` r: 7, w: 6
+	//
+	if result.seq < d.readIndex {
+		return nil, false
+	}
+
+	// When the seq value is greater than the current read index that means a
+	// value was read from idx that overwrote the value that was expected to
+	// be at this idx. This happens when the writer has lapped the reader. The
+	// reader needs to catch up to the writer so it moves its write head to
+	// the new seq, effectively dropping the messages that were not read in
+	// between the two values.
+	//
+	// Here is a simulation of this scenario:
+	//
+	// 1. Both the read and write heads start at 0.
+	//    `| nil | nil | nil | nil |` r: 0, w: 0
+	// 2. The writer fills the buffer.
+	//    `| 0 | 1 | 2 | 3 |` r: 0, w: 4
+	// 3. The writer laps the read head.
+	//    `| 4 | 5 | 2 | 3 |` r: 0, w: 6
+	// 4. The reader reads the first value, expecting a seq of 0 but reads 4,
+	//    this forces the reader to fast forward to 5.
+	//    `| 4 | 5 | 2 | 3 |` r: 5, w: 6
+	//
+	if result.seq > d.readIndex {
+		dropped := result.seq - d.readIndex
+		d.readIndex = result.seq
+		d.alerter.Alert(int(dropped))
+	}
+
+	// Only increment read index if a regular read occurred (where seq was
+	// equal to readIndex) or a value was read that caused a fast forward
+	// (where seq was greater than readIndex).
+	//
+	d.readIndex++
+	return result.data, true
+}

--- a/src/stackdriver-nozzle/vendor/code.cloudfoundry.org/diodes/one_to_one.go
+++ b/src/stackdriver-nozzle/vendor/code.cloudfoundry.org/diodes/one_to_one.go
@@ -1,0 +1,123 @@
+package diodes
+
+import (
+	"sync/atomic"
+	"unsafe"
+)
+
+// GenericDataType is the data type the diodes operate on.
+type GenericDataType unsafe.Pointer
+
+// Alerter is used to report how many values were overwritten since the
+// last write.
+type Alerter interface {
+	Alert(missed int)
+}
+
+// AlerFunc type is an adapter to allow the use of ordinary functions as
+// Alert handlers.
+type AlertFunc func(missed int)
+
+// Alert calls f(missed)
+func (f AlertFunc) Alert(missed int) {
+	f(missed)
+}
+
+type bucket struct {
+	data GenericDataType
+	seq  uint64 // seq is the recorded write index at the time of writing
+}
+
+// OneToOne diode is meant to be used by a single reader and a single writer.
+// It is not thread safe if used otherwise.
+type OneToOne struct {
+	buffer     []unsafe.Pointer
+	writeIndex uint64
+	readIndex  uint64
+	alerter    Alerter
+}
+
+// NewOneToOne creates a new diode is meant to be used by a single reader and
+// a single writer.
+func NewOneToOne(size int, alerter Alerter) *OneToOne {
+	return &OneToOne{
+		buffer:  make([]unsafe.Pointer, size),
+		alerter: alerter,
+	}
+}
+
+// Set sets the data in the next slot of the ring buffer.
+func (d *OneToOne) Set(data GenericDataType) {
+	idx := d.writeIndex % uint64(len(d.buffer))
+
+	newBucket := &bucket{
+		data: data,
+		seq:  d.writeIndex,
+	}
+	d.writeIndex++
+
+	atomic.StorePointer(&d.buffer[idx], unsafe.Pointer(newBucket))
+}
+
+// TryNext will attempt to read from the next slot of the ring buffer.
+// If there is no data available, it will return (nil, false).
+func (d *OneToOne) TryNext() (data GenericDataType, ok bool) {
+	// Read a value from the ring buffer based on the readIndex.
+	idx := d.readIndex % uint64(len(d.buffer))
+	result := (*bucket)(atomic.SwapPointer(&d.buffer[idx], nil))
+
+	// When the result is nil that means the writer has not had the
+	// opportunity to write a value into the diode. This value must be ignored
+	// and the read head must not increment.
+	if result == nil {
+		return nil, false
+	}
+
+	// When the seq value is less than the current read index that means a
+	// value was read from idx that was previously written but has since has
+	// been dropped. This value must be ignored and the read head must not
+	// increment.
+	//
+	// The simulation for this scenario assumes the fast forward occurred as
+	// detailed below.
+	//
+	// 5. The reader reads again getting seq 5. It then reads again expecting
+	//    seq 6 but gets seq 2. This is a read of a stale value that was
+	//    effectively "dropped" so the read fails and the read head stays put.
+	//    `| 4 | 5 | 2 | 3 |` r: 7, w: 6
+	//
+	if result.seq < d.readIndex {
+		return nil, false
+	}
+
+	// When the seq value is greater than the current read index that means a
+	// value was read from idx that overwrote the value that was expected to
+	// be at this idx. This happens when the writer has lapped the reader. The
+	// reader needs to catch up to the writer so it moves its write head to
+	// the new seq, effectively dropping the messages that were not read in
+	// between the two values.
+	//
+	// Here is a simulation of this scenario:
+	//
+	// 1. Both the read and write heads start at 0.
+	//    `| nil | nil | nil | nil |` r: 0, w: 0
+	// 2. The writer fills the buffer.
+	//    `| 0 | 1 | 2 | 3 |` r: 0, w: 4
+	// 3. The writer laps the read head.
+	//    `| 4 | 5 | 2 | 3 |` r: 0, w: 6
+	// 4. The reader reads the first value, expecting a seq of 0 but reads 4,
+	//    this forces the reader to fast forward to 5.
+	//    `| 4 | 5 | 2 | 3 |` r: 5, w: 6
+	//
+	if result.seq > d.readIndex {
+		dropped := result.seq - d.readIndex
+		d.readIndex = result.seq
+		d.alerter.Alert(int(dropped))
+	}
+
+	// Only increment read index if a regular read occurred (where seq was
+	// equal to readIndex) or a value was read that caused a fast forward
+	// (where seq was greater than readIndex).
+	d.readIndex++
+	return result.data, true
+}

--- a/src/stackdriver-nozzle/vendor/code.cloudfoundry.org/diodes/poller.go
+++ b/src/stackdriver-nozzle/vendor/code.cloudfoundry.org/diodes/poller.go
@@ -1,0 +1,81 @@
+package diodes
+
+import (
+	"time"
+
+	"golang.org/x/net/context"
+)
+
+// Diode is any implementation of a diode.
+type Diode interface {
+	Set(GenericDataType)
+	TryNext() (GenericDataType, bool)
+}
+
+// Poller will poll a diode until a value is available.
+type Poller struct {
+	Diode
+	interval time.Duration
+	ctx      context.Context
+}
+
+// PollerConfigOption can be used to setup the poller.
+type PollerConfigOption func(*Poller)
+
+// WithPollingInterval sets the interval at which the diode is queried
+// for new data. The default is 10ms.
+func WithPollingInterval(interval time.Duration) PollerConfigOption {
+	return PollerConfigOption(func(c *Poller) {
+		c.interval = interval
+	})
+}
+
+// WithPollingContext sets the context to cancel any retrieval (Next()). It
+// will not change any results for adding data (Set()). Default is
+// context.Background().
+func WithPollingContext(ctx context.Context) PollerConfigOption {
+	return PollerConfigOption(func(c *Poller) {
+		c.ctx = ctx
+	})
+}
+
+// NewPoller returns a new Poller that wraps the given diode.
+func NewPoller(d Diode, opts ...PollerConfigOption) *Poller {
+	p := &Poller{
+		Diode:    d,
+		interval: 10 * time.Millisecond,
+		ctx:      context.Background(),
+	}
+
+	for _, o := range opts {
+		o(p)
+	}
+
+	return p
+}
+
+// Next polls the diode until data is available or until the context is done.
+// If the context is done, then nil will be returned.
+func (p *Poller) Next() GenericDataType {
+	for {
+		data, ok := p.Diode.TryNext()
+		if !ok {
+			if p.isDone() {
+				return nil
+			}
+
+			time.Sleep(p.interval)
+			continue
+		}
+		return data
+	}
+}
+
+func (p *Poller) isDone() bool {
+	select {
+	case <-p.ctx.Done():
+		return true
+	default:
+		return false
+	}
+}

--- a/src/stackdriver-nozzle/vendor/code.cloudfoundry.org/diodes/waiter.go
+++ b/src/stackdriver-nozzle/vendor/code.cloudfoundry.org/diodes/waiter.go
@@ -1,0 +1,84 @@
+package diodes
+
+import (
+	"sync"
+
+	"golang.org/x/net/context"
+)
+
+// Waiter will use a conditional mutex to alert the reader to when data is
+// available.
+type Waiter struct {
+	Diode
+	mu  sync.Mutex
+	c   *sync.Cond
+	ctx context.Context
+}
+
+// WaiterConfigOption can be used to setup the waiter.
+type WaiterConfigOption func(*Waiter)
+
+// WithWaiterContext sets the context to cancel any retrieval (Next()). It
+// will not change any results for adding data (Set()). Default is
+// context.Background().
+func WithWaiterContext(ctx context.Context) WaiterConfigOption {
+	return WaiterConfigOption(func(c *Waiter) {
+		c.ctx = ctx
+	})
+}
+
+// NewWaiter returns a new Waiter that wraps the given diode.
+func NewWaiter(d Diode, opts ...WaiterConfigOption) *Waiter {
+	w := new(Waiter)
+	w.Diode = d
+	w.c = sync.NewCond(&w.mu)
+	w.ctx = context.Background()
+
+	for _, opt := range opts {
+		opt(w)
+	}
+
+	go func() {
+		<-w.ctx.Done()
+		w.c.Broadcast()
+	}()
+
+	return w
+}
+
+// Set invokes the wrapped diode's Set with the given data and uses Broadcast
+// to wake up any readers.
+func (w *Waiter) Set(data GenericDataType) {
+	w.Diode.Set(data)
+	w.c.Broadcast()
+}
+
+// Next returns the next data point on the wrapped diode. If there is not any
+// new data, it will Wait for set to be called or the context to be done.
+// If the context is done, then nil will be returned.
+func (w *Waiter) Next() GenericDataType {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	for {
+		data, ok := w.Diode.TryNext()
+		if !ok {
+			if w.isDone() {
+				return nil
+			}
+
+			w.c.Wait()
+			continue
+		}
+		return data
+	}
+}
+
+func (w *Waiter) isDone() bool {
+	select {
+	case <-w.ctx.Done():
+		return true
+	default:
+		return false
+	}
+}

--- a/src/stackdriver-nozzle/vendor/vendor.json
+++ b/src/stackdriver-nozzle/vendor/vendor.json
@@ -63,6 +63,12 @@
 			"revisionTime": "2017-09-07T13:44:44Z"
 		},
 		{
+			"checksumSHA1": "1et4UTXKEAjPvvc0Uqp/YSg8Ego=",
+			"path": "code.cloudfoundry.org/diodes",
+			"revision": "000f8f1e7fb802e51b52e293b6edf4dd247cd20c",
+			"revisionTime": "2017-09-01T20:05:24Z"
+		},
+		{
 			"path": "context",
 			"revision": ""
 		},


### PR DESCRIPTION
Changes for operators (from `develop`):
- Logs will once again appear in the `Global` resource. A dependency update caused the logs to show up under GCE VMs.
- Metric events emitted to Stackdriver Logging (eg `ContainerMetric`) are now bundled in a single log entry instead of a log entry per data point. Example:
```
{
insertId:  "1flxwd4g2lwzl4c"  
 jsonPayload: {
  Metrics: [
   0: {
    EventTime:  "2017-10-11T08:33:25.781744816-07:00"     
    Name:  "dropped.delta"     
    Unit:  ""     
    Value:  0     
   }
   1: {
    EventTime:  "2017-10-11T08:33:25.781744816-07:00"     
    Name:  "dropped.total"     
    Unit:  ""     
    Value:  0     
   }
  ]
 }
 labels: {
  eventType:  "CounterEvent"   
  index:  "53b88475-8f46-4350-977b-2ab027e011e6"   
  job:  "router"   
  origin:  "loggregator.metron"   
 }
 logName:  "<redacted>/logs/cf_logs"  
 receiveTimestamp:  "2017-10-11T15:33:46.261943506Z"  
 resource: {
  labels: {
   project_id:  "<redacted>"    
  }
  type:  "global"   
 }
 timestamp:  "2017-10-11T15:33:46.137456123Z"  
}
```

New Health Metrics (subject to change):
- `heartbeat.firehose.errors.close.normal_close`: Firehose server closed due to slow response
- `heartbeat.firehose.errors.close.policy_violation`: Websocket lost the keep-alive, possibly due to slow response from the nozzle
- `heartbeat.firehose.errors.unknwon`: Unknown error from firehose websocket
- `heartbeat.metrics.events.sampled`: How many events (eg a single CointainerMetric) have been sampled out. This is not a sign of slow response.
- `heartbeat.metrics.events`: How many events have been sent to Stackdriver Monitoring
- `heartbeat.nozzle.events.dropped`: How many events have been dropped in the nozzle due to slow response from the rest of the nozzle. This is an indicator of slow response and need to scale the nozzle.

Changes in functionality:
- Nozzle resumes connection when the firehose websocket is closed. Previously the nozzle would crash and be restarted by BOSH after some time.
- Nozzle now drops events under congestion and emits a metric (`heartbeat.nozzle.events.dropped`) instead of backing up and being disconnected by the firehose.
