### PR TITLE
stackdriver/metric: measure out of order write errors

### DIFF
--- a/src/stackdriver-nozzle/mocks/metric_client.go
+++ b/src/stackdriver-nozzle/mocks/metric_client.go
@@ -14,9 +14,14 @@ type MockClient struct {
 	ListErr        error
 
 	CreateMetricDescriptorFn func(request *monitoringpb.CreateMetricDescriptorRequest) error
+	PostFn                   func(req *monitoringpb.CreateTimeSeriesRequest) error
 }
 
 func (mc *MockClient) Post(req *monitoringpb.CreateTimeSeriesRequest) error {
+	if mc.PostFn != nil {
+		return mc.PostFn(req)
+	}
+
 	mc.Mutex.Lock()
 	mc.MetricReqs = append(mc.MetricReqs, req)
 	mc.Mutex.Unlock()


### PR DESCRIPTION
Once there is more than a single nozzle writing we expect these errors
and should not count them in the same way. These occur when more than a
single nozzle is writing to stackdriver. If nozzle A writes a metric at
time T2 and nozzle B writes a netric at time T1 then nozzle B will get
an error that it is writing out of order.

- Emit `metrics.errors.out_of_order` and `metrics.errors.unknown` to
  help operators understand this.
- Don't output the entire metric request for these errors. That detail
  is useful for tracking down specific errors and this error is tracked
  down.

Fixes #98