### PR TITLE
tile: side-by-side execution of master/develop

### DIFF
--- a/tile.yml.erb
+++ b/tile.yml.erb
@@ -31,6 +31,7 @@ packages:
         username: (( .properties.firehose_username.value || ..cf.uaa.stackdriver_nozzle_credentials.identity ))
         password: (( .properties.firehose_password.value || ..cf.uaa.stackdriver_nozzle_credentials.password ))
         skip_ssl: (( .properties.firehose_skip_ssl.value ))
+        subscription_id: <%=ENV["TILE_NAME"] %>
       credentials:
         application_default_credentials: (( .properties.service_account.value ))
       gcp:


### PR DESCRIPTION
Commit 5000810f allowed for side by side installation of master/develop
nozzles but it did not specify a unique subscription_id. The nozzle
identifies itself to firehose with this value and firehose will shard
across a set of nozzles with the same subscription_id.

- Specify a unique subscription_id as part of the tile configuration.
  On released tiles this will be unchanged: stackdriver-nozzle
  On develop tiles this will be changed: stackdriver-nozzle-develop

Fixes #119