### PR TITLE
tile: use dynamic_ip for nozzle job

### DIFF
--- a/tile.yml.erb
+++ b/tile.yml.erb
@@ -20,8 +20,8 @@ packages:
     memory: 512
     ephemeral_disk: 4096
     cpu: 2
-    dynamic_ip: 0
-    static_ip: 1
+    dynamic_ip: 1
+    static_ip: 0
     instances: 2
     properties:
       firehose:


### PR DESCRIPTION
- pcf 2.0 requirement (updates #125)
- no other jobs reference the nozzle so should have no impact on users