### PR TITLE
Improved Firehose Error Handling

### DIFF
--- a/src/stackdriver-nozzle/app/builder.go
+++ b/src/stackdriver-nozzle/app/builder.go
@@ -44,7 +44,7 @@ func New(c *config.Config, logger lager.Logger) *App {
 	adapterHeartbeater.Start()
 	metricAdapter, err := stackdriver.NewMetricAdapter(c.ProjectID, metricClient, adapterHeartbeater)
 	if err != nil {
-		logger.Error("metricAdapter", err)
+		logger.Fatal("metricAdapter", err)
 	}
 
 	// Create a heartbeater that will write heartbeat events to Stackdriver
@@ -61,7 +61,7 @@ func New(c *config.Config, logger lager.Logger) *App {
 		SkipSslValidation: c.SkipSSL}
 	cfClient, err := cfclient.NewClient(cfConfig)
 	if err != nil {
-		logger.Error("cfClient", err)
+		logger.Fatal("cfClient", err)
 	}
 
 	var appInfoRepository cloudfoundry.AppInfoRepository
@@ -146,7 +146,7 @@ func (a *App) newMetricAdapter() stackdriver.MetricAdapter {
 
 	metricAdapter, err := stackdriver.NewMetricAdapter(a.c.ProjectID, metricClient, a.heartbeater)
 	if err != nil {
-		a.logger.Error("metricAdapter", err)
+		a.logger.Fatal("metricAdapter", err)
 	}
 
 	return metricAdapter

--- a/src/stackdriver-nozzle/app/runner.go
+++ b/src/stackdriver-nozzle/app/runner.go
@@ -38,13 +38,14 @@ func Run(ctx context.Context, a *App) {
 
 	errs, fhErrs := consumer.Start(producer)
 	go func() {
-		for {
-			select {
-			case err := <-errs:
-				a.logger.Error("nozzle", err)
-			case err := <-fhErrs:
-				a.logger.Error("firehose", err)
-			}
+		for err := range errs {
+			a.logger.Error("nozzle", err)
+		}
+
+	}()
+	go func() {
+		for err := range fhErrs {
+			a.logger.Error("firehose", err)
 		}
 	}()
 

--- a/src/stackdriver-nozzle/main.go
+++ b/src/stackdriver-nozzle/main.go
@@ -13,6 +13,7 @@ import (
 func main() {
 	logger := lager.NewLogger("stackdriver-nozzle")
 	logger.RegisterSink(lager.NewWriterSink(os.Stdout, lager.DEBUG))
+	logger.RegisterSink(lager.NewWriterSink(os.Stderr, lager.ERROR))
 
 	cfg, err := config.NewConfig()
 	if err != nil {


### PR DESCRIPTION
- A firehose error would not be drained if the nozzle could not write to stackdriver. Repro: Run the nozzle, unplug your ethernet cable, wait, plug it back in, the errors from firehose disconnecting finally show up. This was due to heartbeater.Increment blocking.
- Ignore empty error messages from Firehose and instrument a metric to track them. This is a bandaid for observed behavior and may be removed if it proves unneeded.
- Write errors to stderr to help understanding of the logs.
- Small optimization to the heartbeat/metric_handler to not block Increment during Flush
- Turn Errors into Fatal calls during app construction to prevent partially valid state. This wasn't ever observed but it is the right thing to do.