### PR TITLE
CI: use sha256 across the board

### DIFF
--- a/ci/pipeline-develop.yml
+++ b/ci/pipeline-develop.yml
@@ -49,16 +49,16 @@ jobs:
       - put: stackdriver-tools-artifacts
         params: {file: candidate/*.tgz}
 
-      - put: stackdriver-tools-artifacts-sha1
-        params: {file: candidate/*.tgz.sha1}
+      - put: stackdriver-tools-artifacts-sha256
+        params: {file: candidate/*.tgz.sha256}
 
   - name: deploy-candidate
     plan:
       - aggregate:
-        - {trigger: true,  passed: [build-candidate],  get: stackdriver-tools,                resource: stackdriver-tools-in}
-        - {trigger: true,  passed: [build-candidate],  get: stackdriver-tools-artifacts,      resource: stackdriver-tools-artifacts}
-        - {trigger: false, passed: [build-candidate],  get: stackdriver-tools-artifacts-sha1, resource: stackdriver-tools-artifacts-sha1}
-        - {trigger: false,                             get: version-semver,                   resource: version-semver}
+        - {trigger: true,  passed: [build-candidate],  get: stackdriver-tools,                  resource: stackdriver-tools-in}
+        - {trigger: true,  passed: [build-candidate],  get: stackdriver-tools-artifacts,        resource: stackdriver-tools-artifacts}
+        - {trigger: false, passed: [build-candidate],  get: stackdriver-tools-artifacts-sha256, resource: stackdriver-tools-artifacts-sha256}
+        - {trigger: false,                             get: version-semver,                     resource: version-semver}
 
       - task: deploy-candidate
         file: stackdriver-tools/ci/tasks/deploy-candidate.yml
@@ -73,7 +73,7 @@ jobs:
                 text: "deploy-candidate failed"
         config:
           params:
-            ssh_bastion_address     : {{ssh_bastion_address}}
+            ssh_bastion_address: {{ssh_bastion_address}}
             ssh_user: {{ssh_user}}
             ssh_key: {{ssh_key}}
             bosh_director_address: {{bosh_director_address}}
@@ -94,12 +94,12 @@ jobs:
     plan:
       - aggregate:
         - {trigger: true,  passed: [build-candidate],   get: stackdriver-tools,                resource: stackdriver-tools-in}
+        - {trigger: true,  passed: [build-candidate],   get: stackdriver-tools-artifacts,      resource: stackdriver-tools-artifacts}
         - {trigger: false,                              get: version-semver,                   resource: version-semver}
 
       - task: build-tile
         file: stackdriver-tools/ci/tasks/build-tile.yml
         params:
-          image_directory: develop-stackdriver-tools
           tile_name: stackdriver-nozzle-develop
           tile_label: Stackdriver Nozzle (develop)
         on_failure:
@@ -114,6 +114,8 @@ jobs:
       - put: stackdriver-nozzle-tile
         params: {file: candidate/*.pivotal}
 
+      - put: stackdriver-nozzle-tile-sha256
+        params: {file: candidate/*.tgz.sha256}
 
 resources:
   - name: stackdriver-tools-in
@@ -132,12 +134,12 @@ resources:
       bucket:   {{bucket_name}}
       regexp:   beta/develop-stackdriver-tools/stackdriver-tools([0-9]+\.[0-9]+\.[0-9]+)\.tgz
 
-  - name: stackdriver-tools-artifacts-sha1
+  - name: stackdriver-tools-artifacts-sha256
     type: gcs-resource
     source:
       json_key: {{service_account_key_json}}
       bucket:   {{bucket_name}}
-      regexp:   beta/develop-stackdriver-tools/stackdriver-tools([0-9]+\.[0-9]+\.[0-9]+)\.tgz.sha1
+      regexp:   beta/develop-stackdriver-tools/stackdriver-tools([0-9]+\.[0-9]+\.[0-9]+)\.tgz.sha256
 
   - name: stackdriver-nozzle-tile
     type: gcs-resource
@@ -145,6 +147,13 @@ resources:
       json_key: {{service_account_key_json}}
       bucket:   {{bucket_name}}
       regexp:   beta/develop-stackdriver-tools/stackdriver-nozzle-tile([0-9]+\.[0-9]+\.[0-9]+)\.pivotal
+
+  - name: stackdriver-nozzle-tile-sha256
+    type: gcs-resource
+    source:
+      json_key: {{service_account_key_json}}
+      bucket:   {{bucket_name}}
+      regexp:   beta/develop-stackdriver-tools/stackdriver-nozzle-tile([0-9]+\.[0-9]+\.[0-9]+)\.pivotal.sha256
 
   - name: version-semver
     type: semver

--- a/ci/pipeline-develop.yml
+++ b/ci/pipeline-develop.yml
@@ -115,7 +115,7 @@ jobs:
         params: {file: candidate/*.pivotal}
 
       - put: stackdriver-nozzle-tile-sha256
-        params: {file: candidate/*.tgz.sha256}
+        params: {file: candidate/*.pivotal.sha256}
 
 resources:
   - name: stackdriver-tools-in

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -77,7 +77,7 @@ jobs:
         params: {file: candidate/*.pivotal}
 
       - put: stackdriver-nozzle-tile-sha256
-        params: {file: candidate/*.tgz.sha256}
+        params: {file: candidate/*.pivotal.sha256}
 
   - name: deploy-candidate
     plan:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -49,19 +49,19 @@ jobs:
       - put: stackdriver-tools-artifacts
         params: {file: candidate/*.tgz}
 
-      - put: stackdriver-tools-artifacts-sha1
-        params: {file: candidate/*.tgz.sha1}
+      - put: stackdriver-tools-artifacts-sha256
+        params: {file: candidate/*.tgz.sha256}
 
   - name: build-tile
     plan:
       - aggregate:
         - {trigger: true,  passed: [build-candidate],   get: stackdriver-tools,                resource: stackdriver-tools-in}
+        - {trigger: true,  passed: [build-candidate],   get: stackdriver-tools-artifacts,      resource: stackdriver-tools-artifacts}
         - {trigger: false,                              get: version-semver,                   resource: version-semver}
 
       - task: build-tile
         file: stackdriver-tools/ci/tasks/build-tile.yml
         params:
-          image_directory: stackdriver-tools
           tile_name: stackdriver-nozzle
           tile_label: Stackdriver Nozzle
         on_failure:
@@ -76,12 +76,15 @@ jobs:
       - put: stackdriver-nozzle-tile
         params: {file: candidate/*.pivotal}
 
+      - put: stackdriver-nozzle-tile-sha256
+        params: {file: candidate/*.tgz.sha256}
+
   - name: deploy-candidate
     plan:
       - aggregate:
         - {trigger: true,  passed: [build-candidate],  get: stackdriver-tools,                resource: stackdriver-tools-in}
         - {trigger: true,  passed: [build-candidate],  get: stackdriver-tools-artifacts,      resource: stackdriver-tools-artifacts}
-        - {trigger: false, passed: [build-candidate],  get: stackdriver-tools-artifacts-sha1, resource: stackdriver-tools-artifacts-sha1}
+        - {trigger: false, passed: [build-candidate],  get: stackdriver-tools-artifacts-sha256, resource: stackdriver-tools-artifacts-sha256}
         - {trigger: false,                             get: version-semver,                   resource: version-semver}
 
       - task: deploy-candidate
@@ -122,7 +125,7 @@ jobs:
         - {trigger: true,  passed: [build-tile],        get: stackdriver-nozzle-tile,          resource: stackdriver-nozzle-tile}
         - {trigger: true,  passed: [deploy-candidate],  get: stackdriver-tools,                resource: stackdriver-tools-in}
         - {trigger: true,  passed: [deploy-candidate],  get: stackdriver-tools-artifacts,      resource: stackdriver-tools-artifacts}
-        - {trigger: false, passed: [deploy-candidate],  get: stackdriver-tools-artifacts-sha1, resource: stackdriver-tools-artifacts-sha1}
+        - {trigger: false, passed: [deploy-candidate],  get: stackdriver-tools-artifacts-sha256, resource: stackdriver-tools-artifacts-sha256}
 
       - task: promote-candidate
         file: stackdriver-tools/ci/tasks/promote-candidate.yml
@@ -139,8 +142,8 @@ jobs:
       - put: stackdriver-tools-artifacts
         params: {file: candidate/latest.tgz}
 
-      - put: stackdriver-tools-artifacts-sha1
-        params: {file: candidate/latest.tgz.sha1}
+      - put: stackdriver-tools-artifacts-sha256
+        params: {file: candidate/latest.tgz.sha256}
 
       - put: stackdriver-nozzle-tile
         params: {file: candidate/latest.pivotal}
@@ -162,12 +165,12 @@ resources:
       bucket:   {{bucket_name}}
       regexp:   beta/stackdriver-tools/stackdriver-tools([0-9]+\.[0-9]+\.[0-9]+)\.tgz
 
-  - name: stackdriver-tools-artifacts-sha1
+  - name: stackdriver-tools-artifacts-sha256
     type: gcs-resource
     source:
       json_key: {{service_account_key_json}}
       bucket:   {{bucket_name}}
-      regexp:   beta/stackdriver-tools/stackdriver-tools([0-9]+\.[0-9]+\.[0-9]+)\.tgz.sha1
+      regexp:   beta/stackdriver-tools/stackdriver-tools([0-9]+\.[0-9]+\.[0-9]+)\.tgz.sha256
 
   - name: stackdriver-nozzle-tile
     type: gcs-resource
@@ -175,6 +178,13 @@ resources:
       json_key: {{service_account_key_json}}
       bucket:   {{bucket_name}}
       regexp:   beta/stackdriver-tools/stackdriver-nozzle-tile([0-9]+\.[0-9]+\.[0-9]+)\.pivotal
+
+  - name: stackdriver-nozzle-tile-sha256
+    type: gcs-resource
+    source:
+      json_key: {{service_account_key_json}}
+      bucket:   {{bucket_name}}
+      regexp:   beta/stackdriver-tools/stackdriver-nozzle-tile([0-9]+\.[0-9]+\.[0-9]+)\.pivotal.sha256
 
   - name: version-semver
     type: semver

--- a/ci/tasks/build-candidate.sh
+++ b/ci/tasks/build-candidate.sh
@@ -20,7 +20,7 @@ pushd stackdriver-tools
 popd
 
 image_path=stackdriver-tools/dev_releases/${release_name}/${release_name}-${semver}.tgz
-echo -n $(sha1sum $image_path | awk '{print $1}') > $image_path.sha1
+echo -n $(sha256sum $image_path | awk '{print $1}') > $image_path.sha256
 
 mv ${image_path} candidate/
-mv ${image_path}.sha1 candidate/
+mv ${image_path}.sha256 candidate/

--- a/ci/tasks/build-tile.sh
+++ b/ci/tasks/build-tile.sh
@@ -2,7 +2,6 @@
 set -e
 source stackdriver-tools/ci/tasks/utils.sh
 
-check_param "image_directory"
 check_param "tile_name"
 check_param "tile_label"
 
@@ -11,9 +10,7 @@ semver=`cat version-semver/number`
 tile_name="${tile_name:-stackdriver-nozzle}"
 tile_label="${tile_label:-'Stackdriver Nozzle'}"
 
-
-image_name=${release_name}-${semver}.tgz
-image_path="https://storage.googleapis.com/bosh-gcp/beta/${image_directory}/${image_name}"
+image_path="stackdriver-tools-artifacts/${release_name}-${semver}.tgz"
 output_path=candidate/stackdriver-nozzle-${semver}.pivotal
 
 # install dependencies
@@ -31,3 +28,4 @@ echo "${image_path}"
 
 echo "exposing tile"
 mv stackdriver-tools/product/*.pivotal ${output_path}
+echo -n $(sha256sum $output_path | awk '{print $1}') > $output_path.sha256

--- a/ci/tasks/build-tile.sh
+++ b/ci/tasks/build-tile.sh
@@ -10,7 +10,7 @@ semver=`cat version-semver/number`
 tile_name="${tile_name:-stackdriver-nozzle}"
 tile_label="${tile_label:-'Stackdriver Nozzle'}"
 
-image_path="stackdriver-tools-artifacts/${release_name}-${semver}.tgz"
+image_path="$PWD/stackdriver-tools-artifacts/${release_name}-${semver}.tgz"
 output_path=candidate/stackdriver-nozzle-${semver}.pivotal
 
 # install dependencies
@@ -20,6 +20,9 @@ apk add ruby
 pushd "stackdriver-tools"
 	echo "Creating tile.yml"
 	RELEASE_PATH="${image_path}" TILE_NAME="${tile_name}" TILE_LABEL="${tile_label}" erb tile.yml.erb > tile.yml
+	echo "========================================================================"
+	cat tile.yml
+	echo "========================================================================"
 	echo "building tile"
 	tile build ${semver}
 popd

--- a/ci/tasks/build-tile.yml
+++ b/ci/tasks/build-tile.yml
@@ -6,11 +6,11 @@ image_resource:
     repository: cfplatformeng/tile-generator 
 inputs:
   - name: stackdriver-tools
+  - name: stackdriver-tools-artifacts
   - name: version-semver
 outputs:
   - name: candidate
 params:
-  image_directory: replace-me
   tile_name: replace-me
   tile_label: replace-me
 

--- a/ci/tasks/deploy-candidate.sh
+++ b/ci/tasks/deploy-candidate.sh
@@ -148,6 +148,6 @@ EOF
 bosh deployment ${nozzle_manifest_name}
 bosh -n deploy
 
-# Move release and its SHA1
+# Move release and its SHA256
 mv stackdriver-tools-artifacts/*.tgz candidate/latest.tgz
-mv stackdriver-tools-artifacts-sha1/*.tgz.sha1 candidate/latest.tgz.sha1
+mv stackdriver-tools-artifacts-sha256/*.tgz.sha256 candidate/latest.tgz.sha256

--- a/ci/tasks/deploy-candidate.yml
+++ b/ci/tasks/deploy-candidate.yml
@@ -7,7 +7,7 @@ image_resource:
 inputs:
   - name: stackdriver-tools
   - name: stackdriver-tools-artifacts
-  - name: stackdriver-tools-artifacts-sha1
+  - name: stackdriver-tools-artifacts-sha256
   - name: version-semver
 outputs:
   - name: candidate

--- a/ci/tasks/promote-candidate.sh
+++ b/ci/tasks/promote-candidate.sh
@@ -5,5 +5,5 @@ set -e
 source stackdriver-tools/ci/tasks/utils.sh
 
 mv stackdriver-tools-artifacts/*.tgz candidate/latest.tgz
-mv stackdriver-tools-artifacts-sha1/*.tgz.sha1 candidate/latest.tgz.sha1
+mv stackdriver-tools-artifacts-sha256/*.tgz.sha256 candidate/latest.tgz.sha256
 mv stackdriver-nozzle-tile/*.pivotal candidate/latest.pivotal

--- a/ci/tasks/promote-candidate.yml
+++ b/ci/tasks/promote-candidate.yml
@@ -7,7 +7,7 @@ image_resource:
 inputs:
   - name: stackdriver-tools
   - name: stackdriver-tools-artifacts
-  - name: stackdriver-tools-artifacts-sha1
+  - name: stackdriver-tools-artifacts-sha256
   - name: stackdriver-nozzle-tile
 outputs:
   - name: candidate

--- a/tile.yml.erb
+++ b/tile.yml.erb
@@ -11,7 +11,8 @@ icon_file: gcp_logo.png
 packages:
 - name: stackdriver-tools
   type: bosh-release
-  path: <%=ENV["RELEASE_PATH"] %> 
+  files:
+  - path: <%=ENV["RELEASE_PATH"] %>
   jobs:
   - name: stackdriver-nozzle
     templates:

--- a/tile.yml.erb
+++ b/tile.yml.erb
@@ -11,8 +11,7 @@ icon_file: gcp_logo.png
 packages:
 - name: stackdriver-tools
   type: bosh-release
-  files:
-  - path: <%=ENV["RELEASE_PATH"] %>
+  path: <%=ENV["RELEASE_PATH"] %>
   jobs:
   - name: stackdriver-nozzle
     templates:


### PR DESCRIPTION
- output a pivotal.sha256 for tile builds
- change the sha1 to sha256 for bosh release
- (semi related) use the local file system to expose the bosh release to the tile builder instead of the GCS URL