### PR TITLE
Respect metric batches

### DIFF
--- a/src/stackdriver-nozzle/stackdriver/metric_adapter_test.go
+++ b/src/stackdriver-nozzle/stackdriver/metric_adapter_test.go
@@ -235,7 +235,7 @@ var _ = Describe("MetricAdapter", func() {
 			return errors.New("GRPC Stuff. Points must be written in order. Other stuff")
 		}
 
-		subject.PostMetricEvents(metricEvents)
+		Expect(subject.PostMetricEvents(metricEvents)).NotTo(Succeed())
 		Expect(heartbeater.GetCount("metrics.post.errors")).To(Equal(1))
 		Expect(heartbeater.GetCount("metrics.post.errors.out_of_order")).To(Equal(1))
 		Expect(heartbeater.GetCount("metrics.post.errors.unknown")).To(Equal(0))
@@ -247,7 +247,7 @@ var _ = Describe("MetricAdapter", func() {
 		client.PostFn = func(req *monitoringpb.CreateTimeSeriesRequest) error {
 			return errors.New("tragedy strikes")
 		}
-		subject.PostMetricEvents(metricEvents)
+		Expect(subject.PostMetricEvents(metricEvents)).NotTo(Succeed())
 		Expect(heartbeater.GetCount("metrics.post.errors")).To(Equal(1))
 		Expect(heartbeater.GetCount("metrics.post.errors.out_of_order")).To(Equal(0))
 		Expect(heartbeater.GetCount("metrics.post.errors.unknown")).To(Equal(1))

--- a/src/stackdriver-nozzle/stackdriver/metric_adapter_test.go
+++ b/src/stackdriver-nozzle/stackdriver/metric_adapter_test.go
@@ -235,7 +235,7 @@ var _ = Describe("MetricAdapter", func() {
 			return errors.New("GRPC Stuff. Points must be written in order. Other stuff")
 		}
 
-		Expect(subject.PostMetricEvents(metricEvents)).NotTo(Succeed())
+		Expect(subject.PostMetricEvents(metricEvents)).To(Succeed())
 		Expect(heartbeater.GetCount("metrics.post.errors")).To(Equal(1))
 		Expect(heartbeater.GetCount("metrics.post.errors.out_of_order")).To(Equal(1))
 		Expect(heartbeater.GetCount("metrics.post.errors.unknown")).To(Equal(0))

--- a/src/stackdriver-nozzle/stackdriver/metric_adapter_test.go
+++ b/src/stackdriver-nozzle/stackdriver/metric_adapter_test.go
@@ -217,15 +217,15 @@ var _ = Describe("MetricAdapter", func() {
 				},
 			}}}
 
-		subject.PostMetricEvents(metricEvents)
+		Expect(subject.PostMetricEvents(metricEvents)).To(Succeed())
 		Expect(heartbeater.GetCount("metrics.events.count")).To(Equal(2))
-		Expect(heartbeater.GetCount("metrics.count")).To(Equal(3))
-		Expect(heartbeater.GetCount("metrics.requests")).To(Equal(2))
+		Expect(heartbeater.GetCount("metrics.timeseries.count")).To(Equal(3))
+		Expect(heartbeater.GetCount("metrics.requests")).To(Equal(1))
 
-		subject.PostMetricEvents(metricEvents)
+		Expect(subject.PostMetricEvents(metricEvents)).To(Succeed())
 		Expect(heartbeater.GetCount("metrics.events.count")).To(Equal(4))
-		Expect(heartbeater.GetCount("metrics.count")).To(Equal(6))
-		Expect(heartbeater.GetCount("metrics.requests")).To(Equal(4))
+		Expect(heartbeater.GetCount("metrics.timeseries.count")).To(Equal(6))
+		Expect(heartbeater.GetCount("metrics.requests")).To(Equal(2))
 	})
 
 	It("measures out of order errors", func() {
@@ -236,9 +236,9 @@ var _ = Describe("MetricAdapter", func() {
 		}
 
 		subject.PostMetricEvents(metricEvents)
-		Expect(heartbeater.GetCount("metrics.errors")).To(Equal(1))
-		Expect(heartbeater.GetCount("metrics.errors.out_of_order")).To(Equal(1))
-		Expect(heartbeater.GetCount("metrics.errors.unknown")).To(Equal(0))
+		Expect(heartbeater.GetCount("metrics.post.errors")).To(Equal(1))
+		Expect(heartbeater.GetCount("metrics.post.errors.out_of_order")).To(Equal(1))
+		Expect(heartbeater.GetCount("metrics.post.errors.unknown")).To(Equal(0))
 	})
 
 	It("measures unknown errors", func() {
@@ -248,8 +248,8 @@ var _ = Describe("MetricAdapter", func() {
 			return errors.New("tragedy strikes")
 		}
 		subject.PostMetricEvents(metricEvents)
-		Expect(heartbeater.GetCount("metrics.errors")).To(Equal(1))
-		Expect(heartbeater.GetCount("metrics.errors.out_of_order")).To(Equal(0))
-		Expect(heartbeater.GetCount("metrics.errors.unknown")).To(Equal(1))
+		Expect(heartbeater.GetCount("metrics.post.errors")).To(Equal(1))
+		Expect(heartbeater.GetCount("metrics.post.errors.out_of_order")).To(Equal(0))
+		Expect(heartbeater.GetCount("metrics.post.errors.unknown")).To(Equal(1))
 	})
 })


### PR DESCRIPTION
This is restoring what I believe is previous behavior to send requests to Stackdriver Monitoring in batches. I believe the work to group a set of metrics from a single firehose event introduced this regression, but I'm not completely sure. 

This change should significantly (100x) reduce the RPS to Stackdriver Monitoring.

- Change `PostMetricEvents` to collect all provided metrics into a single `TimeSeriesRequest`
- Move out error telemetry to a specialized error object
- Don't fail the entire post on a single error