### PR TITLE
Propagate PostMetricEvents() errors

### DIFF
--- a/src/stackdriver-nozzle/metrics_pipeline/router.go
+++ b/src/stackdriver-nozzle/metrics_pipeline/router.go
@@ -48,7 +48,7 @@ func (r *router) PostMetricEvents(events []*messages.MetricEvent) error {
 	}
 
 	if len(metricEvents) > 0 {
-		r.metricAdapter.PostMetricEvents(metricEvents)
+		return r.metricAdapter.PostMetricEvents(metricEvents)
 	}
 
 	return nil


### PR DESCRIPTION
This will ensure that SD API errors reach stackdriver nozzle log file.