### PR TITLE
Include metric names while deduplicating values in the buffer.

### DIFF
--- a/src/stackdriver-nozzle/messages/metric.go
+++ b/src/stackdriver-nozzle/messages/metric.go
@@ -27,7 +27,11 @@ func (m *MetricEvent) Hash() string {
 	var b bytes.Buffer
 
 	// Extract keys to a slice and sort it
-	keys := make([]string, len(m.Labels), len(m.Labels))
+	numKeys := len(m.Metrics) + len(m.Labels)
+	keys := make([]string, numKeys, numKeys)
+	for _, m := range m.Metrics {
+		keys = append(keys, m.Name)
+	}
 	for k, _ := range m.Labels {
 		keys = append(keys, k)
 	}

--- a/src/stackdriver-nozzle/metrics_pipeline/auto_culled_metrics_buffer_test.go
+++ b/src/stackdriver-nozzle/metrics_pipeline/auto_culled_metrics_buffer_test.go
@@ -51,7 +51,7 @@ var _ = Describe("autoCulledMetricsBuffer", func() {
 		subject.PostMetricEvents([]*messages.MetricEvent{
 			{
 				Labels:  map[string]string{"Name": "a"},
-				Metrics: []*messages.Metric{{Name: "a", Value: 1}},
+				Metrics: []*messages.Metric{{Name: "a", Value: 1}, {Name: "b", Value: 0}},
 			},
 			{
 				Labels:  map[string]string{"Name": "a"},


### PR DESCRIPTION
This will make sure that each set of metrics is deduplicated ("culled")
independently even if they share the same label values.