### PR TITLE
Reduce number and increase consistency of metric/log labels.

### DIFF
--- a/src/stackdriver-nozzle/mocks/label_maker.go
+++ b/src/stackdriver-nozzle/mocks/label_maker.go
@@ -22,6 +22,10 @@ type LabelMaker struct {
 	Labels map[string]string
 }
 
-func (lm *LabelMaker) Build(*events.Envelope) map[string]string {
+func (lm *LabelMaker) MetricLabels(*events.Envelope) map[string]string {
+	return lm.Labels
+}
+
+func (lm *LabelMaker) LogLabels(*events.Envelope) map[string]string {
 	return lm.Labels
 }

--- a/src/stackdriver-nozzle/nozzle/label_maker.go
+++ b/src/stackdriver-nozzle/nozzle/label_maker.go
@@ -17,15 +17,19 @@
 package nozzle
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-nozzle/cloudfoundry"
 	"github.com/cloudfoundry/sonde-go/events"
 )
 
 type LabelMaker interface {
-	Build(*events.Envelope) map[string]string
+	MetricLabels(*events.Envelope) map[string]string
+	LogLabels(*events.Envelope) map[string]string
 }
 
 func NewLabelMaker(appInfoRepository cloudfoundry.AppInfoRepository) LabelMaker {
@@ -36,67 +40,146 @@ type labelMaker struct {
 	appInfoRepository cloudfoundry.AppInfoRepository
 }
 
-func (lm *labelMaker) Build(envelope *events.Envelope) map[string]string {
-	labels := map[string]string{}
+type labelMap map[string]string
 
-	if envelope.Origin != nil {
-		labels["origin"] = envelope.GetOrigin()
+func (labels labelMap) setIfNotEmpty(key, value string) {
+	if value != "" {
+		labels[key] = value
 	}
+}
 
-	if envelope.EventType != nil {
-		labels["eventType"] = envelope.GetEventType().String()
-	}
+type pathMaker struct {
+	buf bytes.Buffer
+}
 
-	if envelope.Job != nil {
-		labels["job"] = envelope.GetJob()
+func (pm *pathMaker) addElement(key, value string) {
+	pm.buf.WriteByte('/')
+	if value != "" {
+		pm.buf.WriteString(value)
+	} else {
+		pm.buf.WriteString("unknown_")
+		pm.buf.WriteString(key)
 	}
+}
 
-	if envelope.Index != nil {
-		labels["index"] = envelope.GetIndex()
-	}
+func (pm *pathMaker) String() string {
+	return pm.buf.String()
+}
 
-	if appId := lm.getApplicationId(envelope); appId != "" {
-		labels["applicationId"] = appId
-		lm.buildAppMetadataLabels(appId, labels, envelope)
-	}
+// MetricLabels extracts metric metadata from the event envelope and event
+// contained within, and constructs a set of Stackdriver (SD) metric labels
+// from them.
+//
+// Since SD only allows 10 custom labels per metric, we collapse application
+// metadata into a "path" representing the serving application, space, and org.
+// We maintain vm and application instance indexes as separate labels so that
+// it is easy to aggregate across multiple instances.
+func (lm *labelMaker) MetricLabels(envelope *events.Envelope) map[string]string {
+	labels := labelMap{}
+
+	labels.setIfNotEmpty("job", envelope.GetJob())
+	labels.setIfNotEmpty("index", envelope.GetIndex())
+	labels.setIfNotEmpty("applicationPath", lm.getApplicationPath(envelope))
+	labels.setIfNotEmpty("instanceIndex", getInstanceIndex(envelope))
+	labels.setIfNotEmpty("tags", getTags(envelope))
 
 	return labels
 }
 
-func (lm *labelMaker) getApplicationId(envelope *events.Envelope) string {
-	if envelope.GetEventType() == events.Envelope_HttpStartStop {
-		return formatUUID(envelope.GetHttpStartStop().GetApplicationId())
-	} else if envelope.GetEventType() == events.Envelope_LogMessage {
-		return envelope.GetLogMessage().GetAppId()
-	} else if envelope.GetEventType() == events.Envelope_ContainerMetric {
-		return envelope.GetContainerMetric().GetApplicationId()
-	} else {
-		return ""
-	}
+// LogLabels extracts log metadata from the event envelope and event contained
+// within and constructs a set of Stackdriver (SD) log labels from them.
+//
+// This differs from MetricLabels because we want to retain the event type
+// and origin in logs so that we can process logs of a given type easily.
+// The limit of 10 custom labels does not (appear to) apply to SD logging,
+// so there's no risk to adding extra labels here.
+func (lm *labelMaker) LogLabels(envelope *events.Envelope) map[string]string {
+	labels := labelMap(lm.MetricLabels(envelope))
+	labels.setIfNotEmpty("origin", envelope.GetOrigin())
+	labels.setIfNotEmpty("eventType", envelope.GetEventType().String())
+	return labels
 }
 
-func (lm *labelMaker) buildAppMetadataLabels(guid string, labels map[string]string, envelope *events.Envelope) {
-	app := lm.appInfoRepository.GetAppInfo(guid)
-
-	if app.AppName != "" {
-		labels["appName"] = app.AppName
+// getApplicationPath returns a path that uniquely identifies a
+// collection of instances of a given application running in an org + space.
+// The path hierarchy is /org/space/application, e.g.
+//     /system/autoscaling/autoscale
+func (lm *labelMaker) getApplicationPath(envelope *events.Envelope) string {
+	appID := getApplicationId(envelope)
+	if appID == "" {
+		return ""
+	}
+	app := lm.appInfoRepository.GetAppInfo(appID)
+	if app.AppName == "" {
+		return ""
 	}
 
-	if app.SpaceName != "" {
-		labels["spaceName"] = app.SpaceName
+	path := pathMaker{}
+	path.addElement("org", app.OrgName)
+	path.addElement("space", app.SpaceName)
+	path.addElement("application", app.AppName)
+
+	return path.String()
+}
+
+// getApplicationId extracts the application UUID from the event contained
+// within the envelope, for those events that have application IDs.
+func getApplicationId(envelope *events.Envelope) string {
+	switch envelope.GetEventType() {
+	case events.Envelope_HttpStartStop:
+		return formatUUID(envelope.GetHttpStartStop().GetApplicationId())
+	case events.Envelope_LogMessage:
+		return envelope.GetLogMessage().GetAppId()
+	case events.Envelope_ContainerMetric:
+		return envelope.GetContainerMetric().GetApplicationId()
+	}
+	return ""
+}
+
+// getInstanceIndex extracts the instance index or UUID from the event
+// contained within the envelope, for those events that have instance IDs.
+func getInstanceIndex(envelope *events.Envelope) string {
+	switch envelope.GetEventType() {
+	case events.Envelope_HttpStartStop:
+		hss := envelope.GetHttpStartStop()
+		if hss != nil && hss.InstanceIndex != nil {
+			return fmt.Sprintf("%d", hss.GetInstanceIndex())
+		}
+		// Sometimes InstanceIndex is not set but InstanceId is; fall back.
+		return hss.GetInstanceId()
+	case events.Envelope_LogMessage:
+		return envelope.GetLogMessage().GetSourceInstance()
+	case events.Envelope_ContainerMetric:
+		return fmt.Sprintf("%d", envelope.GetContainerMetric().GetInstanceIndex())
+	}
+	return ""
+}
+
+// getTags extracts any additional tags from the envelope and returns them
+// serialized as a single comma-separated string of key=value, sorted by key.
+//
+// This is sub-optimal, but we can't directly map tags to labels because
+// some entities writing metrics to the firehose use different tag sets
+// for metrics with the same origin + name. Since metric label keys form
+// part of the metric descriptor in SD, this would result in some metrics
+// not having the correct descriptor and being dropped.
+func getTags(envelope *events.Envelope) string {
+	tags := envelope.GetTags()
+	if len(tags) == 0 {
+		return ""
 	}
 
-	if app.SpaceGUID != "" {
-		labels["spaceGuid"] = app.SpaceGUID
+	tagKeys := make([]string, 0, len(tags))
+	for k := range tags {
+		tagKeys = append(tagKeys, k)
 	}
+	sort.Strings(tagKeys)
 
-	if app.OrgName != "" {
-		labels["orgName"] = app.OrgName
+	tagElems := make([]string, len(tags))
+	for i, k := range tagKeys {
+		tagElems[i] = k + "=" + tags[k]
 	}
-
-	if app.OrgGUID != "" {
-		labels["orgGuid"] = app.OrgGUID
-	}
+	return strings.Join(tagElems, ",")
 }
 
 func formatUUID(uuid *events.UUID) string {

--- a/src/stackdriver-nozzle/nozzle/label_maker_test.go
+++ b/src/stackdriver-nozzle/nozzle/label_maker_test.go
@@ -48,6 +48,7 @@ var _ = Describe("LabelMaker", func() {
 		ip := "192.168.1.1"
 		tags := map[string]string{
 			"foo": "bar",
+			"bar": "foo",
 		}
 
 		envelope = &events.Envelope{
@@ -61,13 +62,20 @@ var _ = Describe("LabelMaker", func() {
 			Tags:       tags,
 		}
 
-		labels := subject.Build(envelope)
+		metricLabels := subject.MetricLabels(envelope)
+		logLabels := subject.LogLabels(envelope)
 
-		Expect(labels).To(Equal(map[string]string{
-			"origin":    origin,
-			"eventType": eventType.String(),
+		Expect(metricLabels).To(Equal(map[string]string{
+			"job":   job,
+			"index": index,
+			"tags":  "bar=foo,foo=bar",
+		}))
+		Expect(logLabels).To(Equal(map[string]string{
 			"job":       job,
 			"index":     index,
+			"tags":      "bar=foo,foo=bar",
+			"origin":    origin,
+			"eventType": "HttpStartStop",
 		}))
 	})
 
@@ -92,13 +100,12 @@ var _ = Describe("LabelMaker", func() {
 			Tags:       tags,
 		}
 
-		labels := subject.Build(envelope)
+		labels := subject.MetricLabels(envelope)
 
 		Expect(labels).To(Equal(map[string]string{
-			"origin":    origin,
-			"eventType": eventType.String(),
-			"job":       job,
-			"index":     index,
+			"job":   job,
+			"index": index,
+			"tags":  "foo=bar",
 		}))
 	})
 
@@ -109,97 +116,6 @@ var _ = Describe("LabelMaker", func() {
 			high    = uint64(0x79d4c3b2020e67a5)
 			appId   = events.UUID{Low: &low, High: &high}
 		)
-
-		Context("application id", func() {
-			It("httpStartStop adds app id when present", func() {
-				eventType := events.Envelope_HttpStartStop
-
-				event := events.HttpStartStop{
-					ApplicationId: &appId,
-				}
-				envelope := &events.Envelope{
-					EventType:     &eventType,
-					HttpStartStop: &event,
-				}
-
-				labels := subject.Build(envelope)
-
-				Expect(labels["applicationId"]).To(Equal(appGuid))
-			})
-
-			It("LogMessage adds app id", func() {
-				eventType := events.Envelope_LogMessage
-
-				event := events.LogMessage{
-					AppId: &appGuid,
-				}
-				envelope := &events.Envelope{
-					EventType:  &eventType,
-					LogMessage: &event,
-				}
-
-				labels := subject.Build(envelope)
-
-				Expect(labels["applicationId"]).To(Equal(appGuid))
-			})
-
-			It("ValueMetric does not add app id", func() {
-				eventType := events.Envelope_ValueMetric
-
-				event := events.ValueMetric{}
-				envelope := &events.Envelope{
-					EventType:   &eventType,
-					ValueMetric: &event,
-				}
-
-				labels := subject.Build(envelope)
-				Expect(labels).NotTo(HaveKey("applicationId"))
-			})
-
-			It("CounterEvent does not add app id", func() {
-				eventType := events.Envelope_CounterEvent
-
-				event := events.CounterEvent{}
-				envelope := &events.Envelope{
-					EventType:    &eventType,
-					CounterEvent: &event,
-				}
-
-				labels := subject.Build(envelope)
-
-				Expect(labels).NotTo(HaveKey("applicationId"))
-			})
-
-			It("Error does not add app id", func() {
-				eventType := events.Envelope_Error
-
-				event := events.Error{}
-				envelope := &events.Envelope{
-					EventType: &eventType,
-					Error:     &event,
-				}
-
-				labels := subject.Build(envelope)
-
-				Expect(labels).NotTo(HaveKey("applicationId"))
-			})
-
-			It("ContainerMetric does add app id", func() {
-				eventType := events.Envelope_ContainerMetric
-
-				event := events.ContainerMetric{
-					ApplicationId: &appGuid,
-				}
-				envelope := &events.Envelope{
-					EventType:       &eventType,
-					ContainerMetric: &event,
-				}
-
-				labels := subject.Build(envelope)
-
-				Expect(labels["applicationId"]).To(Equal(appGuid))
-			})
-		})
 
 		Context("application metadata", func() {
 			var (
@@ -215,16 +131,18 @@ var _ = Describe("LabelMaker", func() {
 
 			Context("for a LogMessage", func() {
 				var (
-					eventType = events.Envelope_LogMessage
-					event     *events.LogMessage
-					envelope  *events.Envelope
-					spaceGuid = "2ab560c3-3f21-45e0-9452-d748ff3a15e9"
-					orgGuid   = "b494fb47-3c44-4a98-9a08-d839ec5c799b"
+					eventType    = events.Envelope_LogMessage
+					event        *events.LogMessage
+					envelope     *events.Envelope
+					spaceGuid    = "2ab560c3-3f21-45e0-9452-d748ff3a15e9"
+					orgGuid      = "b494fb47-3c44-4a98-9a08-d839ec5c799b"
+					instanceGuid = "301f96f1-97f8-42f8-aa98-6f13ea1f0b87"
 				)
 
 				BeforeEach(func() {
 					event = &events.LogMessage{
-						AppId: &appGuid,
+						AppId:          &appGuid,
+						SourceInstance: &instanceGuid,
 					}
 					envelope = &events.Envelope{
 						EventType:  &eventType,
@@ -243,23 +161,84 @@ var _ = Describe("LabelMaker", func() {
 
 					appInfoRepository.AppInfoMap[appGuid] = app
 
-					labels := subject.Build(envelope)
+					labels := subject.MetricLabels(envelope)
 
-					Expect(labels).To(HaveKeyWithValue("appName", app.AppName))
-					Expect(labels).To(HaveKeyWithValue("spaceName", app.SpaceName))
-					Expect(labels).To(HaveKeyWithValue("spaceGuid", app.SpaceGUID))
-					Expect(labels).To(HaveKeyWithValue("orgName", app.OrgName))
-					Expect(labels).To(HaveKeyWithValue("orgGuid", app.OrgGUID))
+					Expect(labels).To(HaveKeyWithValue("applicationPath",
+						"/MyOrg/MySpace/MyApp"))
+					Expect(labels).To(HaveKeyWithValue("instanceIndex",
+						instanceGuid))
 				})
 
 				It("doesn't add fields for an unresolved app", func() {
-					labels := subject.Build(envelope)
+					labels := subject.MetricLabels(envelope)
 
-					Expect(labels).NotTo(HaveKey("appName"))
-					Expect(labels).NotTo(HaveKey("spaceName"))
-					Expect(labels).NotTo(HaveKey("spaceGuid"))
-					Expect(labels).NotTo(HaveKey("orgName"))
-					Expect(labels).NotTo(HaveKey("orgGuid"))
+					Expect(labels).NotTo(HaveKey("applicationPath"))
+				})
+			})
+			Context("for an HttpStartStop", func() {
+				var (
+					eventType    = events.Envelope_HttpStartStop
+					event        *events.HttpStartStop
+					envelope     *events.Envelope
+					spaceGuid    = "2ab560c3-3f21-45e0-9452-d748ff3a15e9"
+					orgGuid      = "b494fb47-3c44-4a98-9a08-d839ec5c799b"
+					instanceIdx  = int32(1)
+					instanceGuid = "485a10c1-917f-4d89-a98f-dc539ba14dfd"
+				)
+
+				BeforeEach(func() {
+					event = &events.HttpStartStop{
+						ApplicationId: &appId,
+						InstanceIndex: &instanceIdx,
+						InstanceId:    &instanceGuid,
+					}
+					envelope = &events.Envelope{
+						EventType:     &eventType,
+						HttpStartStop: event,
+					}
+				})
+
+				It("adds fields for a resolved app", func() {
+					app := cloudfoundry.AppInfo{
+						AppName:   "MyApp",
+						SpaceName: "MySpace",
+						SpaceGUID: spaceGuid,
+						OrgName:   "MyOrg",
+						OrgGUID:   orgGuid,
+					}
+
+					appInfoRepository.AppInfoMap[appGuid] = app
+
+					labels := subject.MetricLabels(envelope)
+
+					Expect(labels).To(HaveKeyWithValue("applicationPath",
+						"/MyOrg/MySpace/MyApp"))
+					Expect(labels).To(HaveKeyWithValue("instanceIndex", "1"))
+				})
+
+				It("falls back to instance UUID", func() {
+					app := cloudfoundry.AppInfo{
+						AppName:   "MyApp",
+						SpaceName: "MySpace",
+						SpaceGUID: spaceGuid,
+						OrgName:   "MyOrg",
+						OrgGUID:   orgGuid,
+					}
+
+					appInfoRepository.AppInfoMap[appGuid] = app
+
+					envelope.HttpStartStop.InstanceIndex = nil
+					labels := subject.MetricLabels(envelope)
+
+					Expect(labels).To(HaveKeyWithValue("applicationPath",
+						"/MyOrg/MySpace/MyApp"))
+					Expect(labels).To(HaveKeyWithValue("instanceIndex", instanceGuid))
+				})
+
+				It("doesn't add fields for an unresolved app", func() {
+					labels := subject.MetricLabels(envelope)
+
+					Expect(labels).NotTo(HaveKey("applicationPath"))
 				})
 			})
 		})

--- a/src/stackdriver-nozzle/nozzle/log_sink.go
+++ b/src/stackdriver-nozzle/nozzle/log_sink.go
@@ -107,11 +107,11 @@ func (ls *logSink) parseEnvelope(envelope *events.Envelope) messages.Log {
 		}
 	}
 
-	labels := ls.labelMaker.Build(envelope)
-	appID := labels["applicationId"]
-	if appID != "" {
+	labels := ls.labelMaker.LogLabels(envelope)
+	app := labels["applicationPath"]
+	if app != "" {
 		payload["serviceContext"] = map[string]interface{}{
-			"service": appID,
+			"service": app,
 		}
 	}
 

--- a/src/stackdriver-nozzle/nozzle/log_sink_test.go
+++ b/src/stackdriver-nozzle/nozzle/log_sink_test.go
@@ -37,7 +37,7 @@ var _ = Describe("LogSink", func() {
 	)
 
 	BeforeEach(func() {
-		labels = map[string]string{"foo": "bar", "applicationId": "ab313b25-aa48-4a8f-8e7d-d63a6d410e7c"}
+		labels = map[string]string{"foo": "bar", "applicationPath": "/system/autoscaling/autoscale"}
 		labelMaker = &mocks.LabelMaker{Labels: labels}
 		logAdapter = &mocks.LogAdapter{}
 
@@ -128,7 +128,7 @@ var _ = Describe("LogSink", func() {
 				"requestId": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
 			}))
 			Expect(payload).To(HaveKeyWithValue("serviceContext", map[string]interface{}{
-				"service": "ab313b25-aa48-4a8f-8e7d-d63a6d410e7c",
+				"service": "/system/autoscaling/autoscale",
 			}))
 		})
 
@@ -260,7 +260,7 @@ var _ = Describe("LogSink", func() {
 				},
 				"message": "19400: Success: Go",
 				"serviceContext": map[string]interface{}{
-					"service": "ab313b25-aa48-4a8f-8e7d-d63a6d410e7c",
+					"service": "/system/autoscaling/autoscale",
 				},
 			}))
 			Expect(postedLog.Severity).To(Equal(logging.Default))

--- a/src/stackdriver-nozzle/nozzle/metric_sink.go
+++ b/src/stackdriver-nozzle/nozzle/metric_sink.go
@@ -41,7 +41,7 @@ type metricSink struct {
 }
 
 func (ms *metricSink) Receive(envelope *events.Envelope) error {
-	labels := ms.labelMaker.Build(envelope)
+	labels := ms.labelMaker.MetricLabels(envelope)
 
 	// Origin is a required field so this is fine.
 	originPrefix := envelope.GetOrigin() + "."


### PR DESCRIPTION
Stackdriver (SD) imposes a limit of 10 labels per custom metric. Simply copying event metadata into SD labels results in some metrics hitting that limit.
    
To address this, drop eventType and the org, space, and application UUIDs from metric labels completely. Create an "applicationPath" label that concatenates together the org, space and application name.
    
Keep the VM and application index labels separate so that higher level aggregations of the same metric data can be created.
    
Distinguish between the labels applied to log messages and the labels applied to metrics, because distinguishing logs by origin and event type is useful and there doesn't appear to be a similar label limit for SD logging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cloudfoundry-community/stackdriver-tools/136)
<!-- Reviewable:end -->
