### PR TITLE
Make nozzle buffer size configurable via manifest

### DIFF
--- a/jobs/stackdriver-nozzle/spec
+++ b/jobs/stackdriver-nozzle/spec
@@ -36,6 +36,14 @@ properties:
   credentials.application_default_credentials:
     description: Contents of application_default_credentials.json, see https://cloud.google.com/logging/docs/agent/authorization#configuring_client_id_authorization.
 
+  nozzle.metrics_buffer_duration:
+    description: Flush interval (in seconds) of the internal metric buffer
+    default: 30
+
+  nozzle.metrics_buffer_size:
+    description: Batch size for time series being sent to Stackdriver
+    default: 200
+
   nozzle.debug:
     description: Enable debug features for the stackdriver-nozzle for development or troubleshooting
     default: false

--- a/jobs/stackdriver-nozzle/templates/stackdriver-nozzle-ctl.erb
+++ b/jobs/stackdriver-nozzle/templates/stackdriver-nozzle-ctl.erb
@@ -32,6 +32,8 @@ case $1 in
 
     export DEBUG_NOZZLE=<%= p('nozzle.debug', 'false') %>
     export RESOLVE_APP_METADATA=<%= p('nozzle.resolve_app_metadata', 'true') %>
+    export METRICS_BUFFER_DURATION=<%= p('nozzle.metrics_buffer_duration', '30') %>
+    export METRICS_BUFFER_SIZE=<%= p('nozzle.metrics_buffer_size', '200') %>
 
     <% if_p('gcp.project_id') do |prop| %>
     export GCP_PROJECT_ID=<%= prop %>

--- a/src/stackdriver-nozzle/README.md
+++ b/src/stackdriver-nozzle/README.md
@@ -41,10 +41,14 @@ go get github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-nozzl
 
 - `HEARTBEAT_RATE` - how often `stackdriver-nozzle` reports stats to stdout;
   defaults to 30 seconds
-- `BATCH_COUNT` - how many logs and metrics to batch into a single report to
+- `LOGGING_BATCH_COUNT` - how many logs to batch into a single report to
   Stackdriver; defaults to 10
-- `BATCH_DURATION` - maximum time to batch logs to Stackdriver; defaults to 1
+- `LOGGING_BATCH_DURATION` - maximum time to batch logs to Stackdriver; defaults to 1
   second
+- `METRICS_BUFFER_DURATION` - flush interval (in seconds) of the internal metric
+  buffer; defaults to 30
+- `METRICS_BUFFER_SIZE` - batch size for metric time series being sent to
+  Stackdriver; defaults to 200
 - `RESOLVE_APP_METADATA` - whether to hydrate app UUIDs into org name, org
   UUID, space name, space UUID, and app name; defaults to `true`
 - `SUBSCRIPTION_ID` - what subscription ID to use for connecting to the

--- a/src/stackdriver-nozzle/app/builder.go
+++ b/src/stackdriver-nozzle/app/builder.go
@@ -126,8 +126,8 @@ func (a *App) newConsumer(ctx context.Context) (*nozzle.Nozzle, error) {
 func (a *App) newLogAdapter() stackdriver.LogAdapter {
 	logAdapter, logErrs := stackdriver.NewLogAdapter(
 		a.c.ProjectID,
-		a.c.BatchCount,
-		time.Duration(a.c.BatchDuration)*time.Second,
+		a.c.LoggingBatchCount,
+		time.Duration(a.c.LoggingBatchDuration)*time.Second,
 		a.heartbeater,
 	)
 	go func() {

--- a/src/stackdriver-nozzle/config/config.go
+++ b/src/stackdriver-nozzle/config/config.go
@@ -57,19 +57,19 @@ type Config struct {
 	NewlineToken     string `envconfig:"firehose_newline_token"`
 
 	// Stackdriver config
-	ProjectID             string `envconfig:"gcp_project_id"`
-	MetricsBufferDuration int    `envconfig:"metrics_buffer_duration" default:"30"`
-	MetricsBufferSize     int    `envconfig:"metrics_buffer_size" default:"200"`
+	ProjectID            string `envconfig:"gcp_project_id"`
+	LoggingBatchCount    int    `envconfig:"logging_batch_count" default:"10"`
+	LoggingBatchDuration int    `envconfig:"logging_batch_duration" default:"1"`
 
 	// Nozzle config
-	HeartbeatRate      int    `envconfig:"heartbeat_rate" default:"30"`
-	BatchCount         int    `envconfig:"batch_count" default:"10"`
-	BatchDuration      int    `envconfig:"batch_duration" default:"1"`
-	ResolveAppMetadata bool   `envconfig:"resolve_app_metadata"`
-	NozzleId           string `envconfig:"nozzle_id" default:"local-nozzle"`
-	NozzleName         string `envconfig:"nozzle_name" default:"local-nozzle"`
-	NozzleZone         string `envconfig:"nozzle_zone" default:"local-nozzle"`
-	DebugNozzle        bool   `envconfig:"debug_nozzle"`
+	HeartbeatRate         int    `envconfig:"heartbeat_rate" default:"30"`
+	MetricsBufferDuration int    `envconfig:"metrics_buffer_duration" default:"30"`
+	MetricsBufferSize     int    `envconfig:"metrics_buffer_size" default:"200"`
+	ResolveAppMetadata    bool   `envconfig:"resolve_app_metadata"`
+	NozzleId              string `envconfig:"nozzle_id" default:"local-nozzle"`
+	NozzleName            string `envconfig:"nozzle_name" default:"local-nozzle"`
+	NozzleZone            string `envconfig:"nozzle_zone" default:"local-nozzle"`
+	DebugNozzle           bool   `envconfig:"debug_nozzle"`
 }
 
 func (c *Config) validate() error {
@@ -127,8 +127,8 @@ func (c *Config) ToData() lager.Data {
 		"EventsToStackdriverLogging":    c.LoggingEvents,
 		"SkipSSL":                       c.SkipSSL,
 		"ProjectID":                     c.ProjectID,
-		"BatchCount":                    c.BatchCount,
-		"BatchDuration":                 c.BatchDuration,
+		"LoggingBatchCount":             c.LoggingBatchCount,
+		"LoggingBatchDuration":          c.LoggingBatchDuration,
 		"HeartbeatRate":                 c.HeartbeatRate,
 		"ResolveAppMetadata":            c.ResolveAppMetadata,
 		"SubscriptionID":                c.SubscriptionID,

--- a/tile.yml.erb
+++ b/tile.yml.erb
@@ -36,6 +36,9 @@ packages:
         application_default_credentials: (( .properties.service_account.value ))
       gcp:
         project_id: (( .properties.project_id.value ))
+      nozzle:
+        metrics_buffer_duration: (( .properties.metrics_buffer_duration.value ))
+        metrics_buffer_size: (( .properties.metrics_buffer_size.value ))
 
 
 forms:
@@ -79,3 +82,11 @@ forms:
     type: string
     label: Google Project ID
     description: Project id for project with logging and monitoring APIs enabled
+  - name: metrics_buffer_duration
+    type: integer
+    default: 30
+    description: Flush interval (in seconds) of the internal metric buffer
+  - name: metrics_buffer_size
+    type: integer
+    default: 200
+    description: Batch size for time series being sent to Stackdriver


### PR DESCRIPTION
Also, rename `batch_count` and `batch_duration` internally to make it more obvious that they only apply to Stackdriver logging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cloudfoundry-community/stackdriver-tools/138)
<!-- Reviewable:end -->
