### PR TITLE
Move batching to stackdriver.MetricAdapter

### DIFF
--- a/jobs/stackdriver-nozzle/spec
+++ b/jobs/stackdriver-nozzle/spec
@@ -40,7 +40,7 @@ properties:
     description: Flush interval (in seconds) of the internal metric buffer
     default: 30
 
-  nozzle.metrics_buffer_size:
+  nozzle.metrics_batch_size:
     description: Batch size for time series being sent to Stackdriver
     default: 200
 

--- a/jobs/stackdriver-nozzle/templates/stackdriver-nozzle-ctl.erb
+++ b/jobs/stackdriver-nozzle/templates/stackdriver-nozzle-ctl.erb
@@ -33,7 +33,7 @@ case $1 in
     export DEBUG_NOZZLE=<%= p('nozzle.debug', 'false') %>
     export RESOLVE_APP_METADATA=<%= p('nozzle.resolve_app_metadata', 'true') %>
     export METRICS_BUFFER_DURATION=<%= p('nozzle.metrics_buffer_duration', '30') %>
-    export METRICS_BUFFER_SIZE=<%= p('nozzle.metrics_buffer_size', '200') %>
+    export METRICS_BATCH_SIZE=<%= p('nozzle.metrics_batch_size', '200') %>
 
     <% if_p('gcp.project_id') do |prop| %>
     export GCP_PROJECT_ID=<%= prop %>

--- a/src/stackdriver-nozzle/README.md
+++ b/src/stackdriver-nozzle/README.md
@@ -47,7 +47,7 @@ go get github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-nozzl
   second
 - `METRICS_BUFFER_DURATION` - flush interval (in seconds) of the internal metric
   buffer; defaults to 30
-- `METRICS_BUFFER_SIZE` - batch size for metric time series being sent to
+- `METRICS_BATCH_SIZE` - batch size for metric time series being sent to
   Stackdriver; defaults to 200
 - `RESOLVE_APP_METADATA` - whether to hydrate app UUIDs into org name, org
   UUID, space name, space UUID, and app name; defaults to `true`

--- a/src/stackdriver-nozzle/app/builder.go
+++ b/src/stackdriver-nozzle/app/builder.go
@@ -42,7 +42,7 @@ func New(c *config.Config, logger lager.Logger) *App {
 	trigger := time.NewTicker(time.Duration(c.HeartbeatRate) * time.Second).C
 	adapterHeartbeater := heartbeat.NewHeartbeater(logger, trigger, "heartbeater.telemetry.emitted")
 	adapterHeartbeater.Start()
-	metricAdapter, err := stackdriver.NewMetricAdapter(c.ProjectID, metricClient, c.MetricsBatchSize, adapterHeartbeater)
+	metricAdapter, err := stackdriver.NewMetricAdapter(c.ProjectID, metricClient, c.MetricsBatchSize, adapterHeartbeater, logger)
 	if err != nil {
 		logger.Fatal("metricAdapter", err)
 	}
@@ -144,7 +144,7 @@ func (a *App) newMetricAdapter() stackdriver.MetricAdapter {
 		a.logger.Fatal("metricClient", err)
 	}
 
-	metricAdapter, err := stackdriver.NewMetricAdapter(a.c.ProjectID, metricClient, a.c.MetricsBatchSize, a.heartbeater)
+	metricAdapter, err := stackdriver.NewMetricAdapter(a.c.ProjectID, metricClient, a.c.MetricsBatchSize, a.heartbeater, a.logger)
 	if err != nil {
 		a.logger.Fatal("metricAdapter", err)
 	}

--- a/src/stackdriver-nozzle/app/builder.go
+++ b/src/stackdriver-nozzle/app/builder.go
@@ -153,13 +153,8 @@ func (a *App) newMetricAdapter() stackdriver.MetricAdapter {
 }
 
 func (a *App) newMetricSink(ctx context.Context, metricAdapter stackdriver.MetricAdapter) nozzle.Sink {
-	metricBuffer, errs := metrics_pipeline.NewAutoCulledMetricsBuffer(ctx, a.logger, time.Duration(a.c.MetricsBufferDuration)*time.Second, metricAdapter, a.heartbeater)
+	metricBuffer := metrics_pipeline.NewAutoCulledMetricsBuffer(ctx, a.logger, time.Duration(a.c.MetricsBufferDuration)*time.Second, metricAdapter, a.heartbeater)
 	a.bufferEmpty = metricBuffer.IsEmpty
-	go func() {
-		for err := range errs {
-			a.logger.Error("metricsBuffer", err)
-		}
-	}()
 
 	return nozzle.NewMetricSink(a.labelMaker, metricBuffer, nozzle.NewUnitParser())
 }

--- a/src/stackdriver-nozzle/app/builder.go
+++ b/src/stackdriver-nozzle/app/builder.go
@@ -42,7 +42,7 @@ func New(c *config.Config, logger lager.Logger) *App {
 	trigger := time.NewTicker(time.Duration(c.HeartbeatRate) * time.Second).C
 	adapterHeartbeater := heartbeat.NewHeartbeater(logger, trigger, "heartbeater.telemetry.emitted")
 	adapterHeartbeater.Start()
-	metricAdapter, err := stackdriver.NewMetricAdapter(c.ProjectID, metricClient, c.MetricsBufferSize, adapterHeartbeater)
+	metricAdapter, err := stackdriver.NewMetricAdapter(c.ProjectID, metricClient, c.MetricsBatchSize, adapterHeartbeater)
 	if err != nil {
 		logger.Fatal("metricAdapter", err)
 	}
@@ -144,7 +144,7 @@ func (a *App) newMetricAdapter() stackdriver.MetricAdapter {
 		a.logger.Fatal("metricClient", err)
 	}
 
-	metricAdapter, err := stackdriver.NewMetricAdapter(a.c.ProjectID, metricClient, a.c.MetricsBufferSize, a.heartbeater)
+	metricAdapter, err := stackdriver.NewMetricAdapter(a.c.ProjectID, metricClient, a.c.MetricsBatchSize, a.heartbeater)
 	if err != nil {
 		a.logger.Fatal("metricAdapter", err)
 	}

--- a/src/stackdriver-nozzle/app/builder.go
+++ b/src/stackdriver-nozzle/app/builder.go
@@ -86,7 +86,7 @@ func (a *App) newProducer() cloudfoundry.Firehose {
 	return cloudfoundry.NewFirehose(a.cfConfig, a.cfClient, a.c.SubscriptionID)
 }
 
-func (a *App) newConsumer(ctx context.Context) (*nozzle.Nozzle, error) {
+func (a *App) newConsumer(ctx context.Context) (nozzle.Nozzle, error) {
 	logEvents, err := nozzle.ParseEvents(strings.Split(a.c.LoggingEvents, ","))
 	if err != nil {
 		return nil, err
@@ -116,11 +116,7 @@ func (a *App) newConsumer(ctx context.Context) (*nozzle.Nozzle, error) {
 		return nil, err
 	}
 
-	return &nozzle.Nozzle{
-		LogSink:     filteredLogSink,
-		MetricSink:  filteredMetricSink,
-		Heartbeater: a.heartbeater,
-	}, nil
+	return nozzle.NewNozzle(a.logger, filteredLogSink, filteredMetricSink, a.heartbeater), nil
 }
 
 func (a *App) newLogAdapter() stackdriver.LogAdapter {

--- a/src/stackdriver-nozzle/app/builder.go
+++ b/src/stackdriver-nozzle/app/builder.go
@@ -156,5 +156,5 @@ func (a *App) newMetricSink(ctx context.Context, metricAdapter stackdriver.Metri
 	metricBuffer := metrics_pipeline.NewAutoCulledMetricsBuffer(ctx, a.logger, time.Duration(a.c.MetricsBufferDuration)*time.Second, metricAdapter, a.heartbeater)
 	a.bufferEmpty = metricBuffer.IsEmpty
 
-	return nozzle.NewMetricSink(a.labelMaker, metricBuffer, nozzle.NewUnitParser())
+	return nozzle.NewMetricSink(a.logger, a.labelMaker, metricBuffer, nozzle.NewUnitParser())
 }

--- a/src/stackdriver-nozzle/app/runner.go
+++ b/src/stackdriver-nozzle/app/runner.go
@@ -36,12 +36,7 @@ func Run(ctx context.Context, a *App) {
 		a.logger.Fatal("construction", err)
 	}
 
-	fhErrs := consumer.Start(producer)
-	go func() {
-		for err := range fhErrs {
-			a.logger.Error("firehose", err)
-		}
-	}()
+	consumer.Start(producer)
 
 	blockTillInterrupt()
 

--- a/src/stackdriver-nozzle/app/runner.go
+++ b/src/stackdriver-nozzle/app/runner.go
@@ -36,13 +36,7 @@ func Run(ctx context.Context, a *App) {
 		a.logger.Fatal("construction", err)
 	}
 
-	errs, fhErrs := consumer.Start(producer)
-	go func() {
-		for err := range errs {
-			a.logger.Error("nozzle", err)
-		}
-
-	}()
+	fhErrs := consumer.Start(producer)
 	go func() {
 		for err := range fhErrs {
 			a.logger.Error("firehose", err)

--- a/src/stackdriver-nozzle/config/config.go
+++ b/src/stackdriver-nozzle/config/config.go
@@ -64,7 +64,7 @@ type Config struct {
 	// Nozzle config
 	HeartbeatRate         int    `envconfig:"heartbeat_rate" default:"30"`
 	MetricsBufferDuration int    `envconfig:"metrics_buffer_duration" default:"30"`
-	MetricsBufferSize     int    `envconfig:"metrics_buffer_size" default:"200"`
+	MetricsBatchSize      int    `envconfig:"metrics_batch_size" default:"200"`
 	ResolveAppMetadata    bool   `envconfig:"resolve_app_metadata"`
 	NozzleId              string `envconfig:"nozzle_id" default:"local-nozzle"`
 	NozzleName            string `envconfig:"nozzle_name" default:"local-nozzle"`

--- a/src/stackdriver-nozzle/heartbeat/heartbeater.go
+++ b/src/stackdriver-nozzle/heartbeat/heartbeater.go
@@ -36,7 +36,7 @@ type Heartbeater interface {
 
 type Handler interface {
 	Handle(name string, count uint)
-	Flush() error
+	Flush()
 	Name() string
 }
 
@@ -101,9 +101,7 @@ func (h *heartbeater) Start() {
 			case <-h.trigger:
 				h.logger.Info("heartbeater", lager.Data{"debug": fmt.Sprintf("Flushing %v handlers", len(h.handlers))})
 				for _, ha := range h.handlers {
-					if err := ha.Flush(); err != nil {
-						h.logger.Error("heartbeater", err, lager.Data{"handler": ha.Name()})
-					}
+					ha.Flush()
 				}
 			case event := <-h.events:
 				for _, ha := range h.handlers {
@@ -114,9 +112,7 @@ func (h *heartbeater) Start() {
 				h.logger.Info("heartbeater", lager.Data{"debug": fmt.Sprintf("Heartbeat polling done for %v handlers", len(h.handlers))})
 				for _, ha := range h.handlers {
 					h.logger.Info("heartbeater", lager.Data{"debug": "Flushing", "handler": ha.Name()})
-					if err := ha.Flush(); err != nil {
-						h.logger.Error("heartbeater", err, lager.Data{"handler": ha.Name()})
-					}
+					ha.Flush()
 				}
 				h.logger.Info("heartbeater", lager.Data{"debug": "all handlers flushed"})
 				return

--- a/src/stackdriver-nozzle/heartbeat/heartbeater_test.go
+++ b/src/stackdriver-nozzle/heartbeat/heartbeater_test.go
@@ -40,15 +40,11 @@ var _ = Describe("Heartbeater", func() {
 	BeforeEach(func() {
 		trigger = make(chan time.Time)
 
-		// Mock logger
 		logger = &mocks.MockLogger{}
-
-		// Mock heartbeater
 		heartbeater := mocks.NewHeartbeater()
 
-		// Mock metric handler
 		client = &mocks.MockClient{}
-		metricAdapter, _ = stackdriver.NewMetricAdapter("my-awesome-project", client, 200, heartbeater)
+		metricAdapter, _ = stackdriver.NewMetricAdapter("my-awesome-project", client, 200, heartbeater, logger)
 		metricHandler = heartbeat.NewMetricHandler(metricAdapter, logger, "nozzle-id", "nozzle-name", "nozle-zone")
 
 		subject = heartbeat.NewLoggerMetricHeartbeater(metricHandler, logger, trigger, "heartbeater")
@@ -58,9 +54,7 @@ var _ = Describe("Heartbeater", func() {
 	It("should start at zero", func() {
 		trigger <- time.Now()
 
-		Eventually(func() mocks.Log {
-			return logger.LastLog()
-		}).Should(Equal(mocks.Log{
+		Eventually(logger.Logs()).Should(ContainElement(mocks.Log{
 			Level:  lager.INFO,
 			Action: "heartbeater",
 			Datas: []lager.Data{
@@ -76,9 +70,7 @@ var _ = Describe("Heartbeater", func() {
 
 		trigger <- time.Now()
 
-		Eventually(func() mocks.Log {
-			return logger.LastLog()
-		}).Should(Equal(mocks.Log{
+		Eventually(logger.Logs()).Should(ContainElement(mocks.Log{
 			Level:  lager.INFO,
 			Action: "heartbeater",
 			Datas: []lager.Data{
@@ -106,7 +98,7 @@ var _ = Describe("Heartbeater", func() {
 
 		trigger <- time.Now()
 
-		Eventually(logger.LastLog).Should(Equal(mocks.Log{
+		Eventually(logger.Logs()).Should(ContainElement(mocks.Log{
 			Level:  lager.INFO,
 			Action: "heartbeater",
 			Datas: []lager.Data{
@@ -164,9 +156,7 @@ var _ = Describe("Heartbeater", func() {
 
 		trigger <- time.Now()
 
-		Eventually(func() mocks.Log {
-			return logger.LastLog()
-		}).Should(Equal(mocks.Log{
+		Eventually(logger.Logs()).Should(ContainElement(mocks.Log{
 			Level:  lager.INFO,
 			Action: "heartbeater",
 			Datas: []lager.Data{

--- a/src/stackdriver-nozzle/heartbeat/heartbeater_test.go
+++ b/src/stackdriver-nozzle/heartbeat/heartbeater_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Heartbeater", func() {
 
 		// Mock metric handler
 		client = &mocks.MockClient{}
-		metricAdapter, _ = stackdriver.NewMetricAdapter("my-awesome-project", client, heartbeater)
+		metricAdapter, _ = stackdriver.NewMetricAdapter("my-awesome-project", client, 200, heartbeater)
 		metricHandler = heartbeat.NewMetricHandler(metricAdapter, logger, "nozzle-id", "nozzle-name", "nozle-zone")
 
 		subject = heartbeat.NewLoggerMetricHeartbeater(metricHandler, logger, trigger, "heartbeater")
@@ -106,9 +106,7 @@ var _ = Describe("Heartbeater", func() {
 
 		trigger <- time.Now()
 
-		Eventually(func() mocks.Log {
-			return logger.LastLog()
-		}).Should(Equal(mocks.Log{
+		Eventually(logger.LastLog).Should(Equal(mocks.Log{
 			Level:  lager.INFO,
 			Action: "heartbeater",
 			Datas: []lager.Data{

--- a/src/stackdriver-nozzle/heartbeat/logger_handler.go
+++ b/src/stackdriver-nozzle/heartbeat/logger_handler.go
@@ -49,12 +49,11 @@ func (h *loggerHandler) Handle(event string, count uint) {
 	return
 }
 
-func (h *loggerHandler) Flush() error {
+func (h *loggerHandler) Flush() {
 	h.counterMu.Lock()
 	defer h.counterMu.Unlock()
 	h.logger.Info(
 		h.prefix, lager.Data{"counters": h.counter},
 	)
 	h.counter = map[string]uint{}
-	return nil
 }

--- a/src/stackdriver-nozzle/heartbeat/metric_handler.go
+++ b/src/stackdriver-nozzle/heartbeat/metric_handler.go
@@ -61,7 +61,7 @@ func (h *metricHandler) Handle(event string, count uint) {
 	return
 }
 
-func (h *metricHandler) Flush() error {
+func (h *metricHandler) Flush() {
 	counter := h.flushInternal()
 
 	metrics := []*messages.Metric{}
@@ -78,7 +78,7 @@ func (h *metricHandler) Flush() error {
 			EventTime: t,
 		})
 	}
-	return h.ma.PostMetricEvents([]*messages.MetricEvent{{Labels: labels, Metrics: metrics}})
+	h.ma.PostMetricEvents([]*messages.MetricEvent{{Labels: labels, Metrics: metrics}})
 }
 
 func (h *metricHandler) flushInternal() map[string]uint {

--- a/src/stackdriver-nozzle/metrics_pipeline/auto_culled_metrics_buffer.go
+++ b/src/stackdriver-nozzle/metrics_pipeline/auto_culled_metrics_buffer.go
@@ -86,11 +86,7 @@ func (mb *autoCulledMetricsBuffer) IsEmpty() bool {
 }
 
 func (mb *autoCulledMetricsBuffer) flush() {
-	metrics := mb.flushInternalBuffer()
-	count := len(metrics)
-	mb.logger.Info("autoCulledMetricsBuffer", lager.Data{"info": fmt.Sprintf("%v metric events will be flushed", count)})
-
-	err := mb.adapter.PostMetricEvents(metrics)
+	err := mb.adapter.PostMetricEvents(mb.flushInternalBuffer())
 
 	if err != nil {
 		mb.errs <- err

--- a/src/stackdriver-nozzle/metrics_pipeline/auto_culled_metrics_buffer_test.go
+++ b/src/stackdriver-nozzle/metrics_pipeline/auto_culled_metrics_buffer_test.go
@@ -19,8 +19,6 @@ package metrics_pipeline_test
 import (
 	"context"
 	"errors"
-	"fmt"
-	"strconv"
 	"time"
 
 	"sort"
@@ -46,7 +44,7 @@ var _ = Describe("autoCulledMetricsBuffer", func() {
 	})
 
 	It("culls duplicate metrics", func() {
-		subject, _ := NewAutoCulledMetricsBuffer(context.TODO(), logger, 100*time.Millisecond, 5, metricAdapter, heartbeater)
+		subject, _ := NewAutoCulledMetricsBuffer(context.TODO(), logger, 100*time.Millisecond, metricAdapter, heartbeater)
 
 		subject.PostMetricEvents([]*messages.MetricEvent{
 			{
@@ -80,8 +78,7 @@ var _ = Describe("autoCulledMetricsBuffer", func() {
 	})
 
 	It("culls multiple duplicates, keeping the latest", func() {
-		subject, _ := NewAutoCulledMetricsBuffer(context.TODO(), logger, 100*time.Millisecond, 5, metricAdapter, heartbeater)
-
+		subject, _ := NewAutoCulledMetricsBuffer(context.TODO(), logger, 100*time.Millisecond, metricAdapter, heartbeater)
 		subject.PostMetricEvents([]*messages.MetricEvent{
 			{
 				Labels:  map[string]string{"d1": "a"},
@@ -131,7 +128,7 @@ var _ = Describe("autoCulledMetricsBuffer", func() {
 
 	It("it buffers metrics for the expected duration before flushing", func() {
 		d := 500 * time.Millisecond
-		subject, _ := NewAutoCulledMetricsBuffer(context.TODO(), logger, d, 5, metricAdapter, heartbeater)
+		subject, _ := NewAutoCulledMetricsBuffer(context.TODO(), logger, d, metricAdapter, heartbeater)
 
 		subject.PostMetricEvents([]*messages.MetricEvent{
 			{
@@ -150,7 +147,7 @@ var _ = Describe("autoCulledMetricsBuffer", func() {
 	It("it flushes metrics when the context is canceled", func() {
 		d := 500 * time.Second
 		ctx, cancel := context.WithCancel(context.Background())
-		subject, _ := NewAutoCulledMetricsBuffer(ctx, logger, d, 5, metricAdapter, heartbeater)
+		subject, _ := NewAutoCulledMetricsBuffer(ctx, logger, d, metricAdapter, heartbeater)
 
 		subject.PostMetricEvents([]*messages.MetricEvent{
 			{
@@ -166,46 +163,9 @@ var _ = Describe("autoCulledMetricsBuffer", func() {
 		Eventually(metricAdapter.GetPostedMetricEvents).Should(HaveLen(2))
 	})
 
-	It("it posts the metrics in correct batch size", func() {
-		d := 10 * time.Millisecond
-		batchSize := 200
-
-		metricAdapter.PostMetricEventsFn = func(metricEvents []*messages.MetricEvent) error {
-			if len(metricEvents) > batchSize {
-				return fmt.Errorf("Batch size (%v) exceeded max (%v)", len(metricEvents), batchSize)
-			}
-
-			metricAdapter.PostedMetricEvents = append(metricAdapter.PostedMetricEvents, metricEvents...)
-			return metricAdapter.PostMetricEventsError
-		}
-
-		metricGroupSizes := []int{199, 200, 201, 399, 400, 1999, 2000, 2001}
-
-		// Test various numbers of metrics being posted to the buffer
-		for _, groupSize := range metricGroupSizes {
-			ctx, cancel := context.WithCancel(context.Background())
-			metricAdapter.PostedMetricEvents = []*messages.MetricEvent{}
-			metricAdapter.PostMetricEventsError = nil
-			subject, errs := NewAutoCulledMetricsBuffer(ctx, logger, d, batchSize, metricAdapter, heartbeater)
-			for i := 0; i < groupSize; i++ {
-				subject.PostMetricEvents([]*messages.MetricEvent{
-					{
-						Labels:  map[string]string{"Name": strconv.Itoa(i)},
-						Metrics: []*messages.Metric{{Value: 1, EventTime: time.Unix(1234567890+int64(i), 0)}},
-					},
-				})
-			}
-			cancel()
-			err := <-errs
-			Expect(err).ToNot(HaveOccurred())
-			Expect(metricAdapter.PostedMetricEvents).To(HaveLen(groupSize))
-		}
-
-	})
-
 	It("sends errors through the error channel", func() {
 		d := 1 * time.Millisecond
-		subject, errs := NewAutoCulledMetricsBuffer(context.TODO(), logger, d, 5, metricAdapter, heartbeater)
+		subject, errs := NewAutoCulledMetricsBuffer(context.TODO(), logger, d, metricAdapter, heartbeater)
 
 		expectedErr := errors.New("fail")
 		metricAdapter.PostMetricEventsError = expectedErr
@@ -234,7 +194,7 @@ var _ = Describe("autoCulledMetricsBuffer", func() {
 				return nil
 			}
 
-			subject, _ = NewAutoCulledMetricsBuffer(context.TODO(), logger, 1*time.Millisecond, 5, metricAdapter, heartbeater)
+			subject, _ = NewAutoCulledMetricsBuffer(context.TODO(), logger, 1*time.Millisecond, metricAdapter, heartbeater)
 		})
 
 		It("doesn't block new metrics during flush", func() {

--- a/src/stackdriver-nozzle/metrics_pipeline/auto_culled_metrics_buffer_test.go
+++ b/src/stackdriver-nozzle/metrics_pipeline/auto_culled_metrics_buffer_test.go
@@ -18,7 +18,6 @@ package metrics_pipeline_test
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"sort"
@@ -44,7 +43,7 @@ var _ = Describe("autoCulledMetricsBuffer", func() {
 	})
 
 	It("culls duplicate metrics", func() {
-		subject, _ := NewAutoCulledMetricsBuffer(context.TODO(), logger, 100*time.Millisecond, metricAdapter, heartbeater)
+		subject := NewAutoCulledMetricsBuffer(context.TODO(), logger, 100*time.Millisecond, metricAdapter, heartbeater)
 
 		subject.PostMetricEvents([]*messages.MetricEvent{
 			{
@@ -78,7 +77,7 @@ var _ = Describe("autoCulledMetricsBuffer", func() {
 	})
 
 	It("culls multiple duplicates, keeping the latest", func() {
-		subject, _ := NewAutoCulledMetricsBuffer(context.TODO(), logger, 100*time.Millisecond, metricAdapter, heartbeater)
+		subject := NewAutoCulledMetricsBuffer(context.TODO(), logger, 100*time.Millisecond, metricAdapter, heartbeater)
 		subject.PostMetricEvents([]*messages.MetricEvent{
 			{
 				Labels:  map[string]string{"d1": "a"},
@@ -128,7 +127,7 @@ var _ = Describe("autoCulledMetricsBuffer", func() {
 
 	It("it buffers metrics for the expected duration before flushing", func() {
 		d := 500 * time.Millisecond
-		subject, _ := NewAutoCulledMetricsBuffer(context.TODO(), logger, d, metricAdapter, heartbeater)
+		subject := NewAutoCulledMetricsBuffer(context.TODO(), logger, d, metricAdapter, heartbeater)
 
 		subject.PostMetricEvents([]*messages.MetricEvent{
 			{
@@ -147,7 +146,7 @@ var _ = Describe("autoCulledMetricsBuffer", func() {
 	It("it flushes metrics when the context is canceled", func() {
 		d := 500 * time.Second
 		ctx, cancel := context.WithCancel(context.Background())
-		subject, _ := NewAutoCulledMetricsBuffer(ctx, logger, d, metricAdapter, heartbeater)
+		subject := NewAutoCulledMetricsBuffer(ctx, logger, d, metricAdapter, heartbeater)
 
 		subject.PostMetricEvents([]*messages.MetricEvent{
 			{
@@ -161,23 +160,6 @@ var _ = Describe("autoCulledMetricsBuffer", func() {
 		})
 		cancel()
 		Eventually(metricAdapter.GetPostedMetricEvents).Should(HaveLen(2))
-	})
-
-	It("sends errors through the error channel", func() {
-		d := 1 * time.Millisecond
-		subject, errs := NewAutoCulledMetricsBuffer(context.TODO(), logger, d, metricAdapter, heartbeater)
-
-		expectedErr := errors.New("fail")
-		metricAdapter.PostMetricEventsError = expectedErr
-
-		metricEvent := []*messages.MetricEvent{{}}
-		subject.PostMetricEvents(metricEvent)
-
-		Eventually(metricAdapter.GetPostedMetricEvents).Should(HaveLen(1))
-
-		var err error
-		Eventually(errs).Should(Receive(&err))
-		Expect(err).To(Equal(expectedErr))
 	})
 
 	Describe("with a slow MetricAdapter", func() {
@@ -194,7 +176,7 @@ var _ = Describe("autoCulledMetricsBuffer", func() {
 				return nil
 			}
 
-			subject, _ = NewAutoCulledMetricsBuffer(context.TODO(), logger, 1*time.Millisecond, metricAdapter, heartbeater)
+			subject = NewAutoCulledMetricsBuffer(context.TODO(), logger, 1*time.Millisecond, metricAdapter, heartbeater)
 		})
 
 		It("doesn't block new metrics during flush", func() {

--- a/src/stackdriver-nozzle/metrics_pipeline/metrics_pipeline_suite_test.go
+++ b/src/stackdriver-nozzle/metrics_pipeline/metrics_pipeline_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestMetricsBuffer(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "MetricsBuffer Suite")
+	RunSpecs(t, "MetricsPipeline Suite")
 }

--- a/src/stackdriver-nozzle/metrics_pipeline/router.go
+++ b/src/stackdriver-nozzle/metrics_pipeline/router.go
@@ -31,7 +31,7 @@ func NewRouter(metricAdapter stackdriver.MetricAdapter, metricEvents []events.En
 	return r
 }
 
-func (r *router) PostMetricEvents(events []*messages.MetricEvent) error {
+func (r *router) PostMetricEvents(events []*messages.MetricEvent) {
 	metricEvents := []*messages.MetricEvent{}
 	for i := range events {
 		if r.metricEvents[events[i].Type] {
@@ -48,8 +48,6 @@ func (r *router) PostMetricEvents(events []*messages.MetricEvent) error {
 	}
 
 	if len(metricEvents) > 0 {
-		return r.metricAdapter.PostMetricEvents(metricEvents)
+		r.metricAdapter.PostMetricEvents(metricEvents)
 	}
-
-	return nil
 }

--- a/src/stackdriver-nozzle/metrics_pipeline/router_test.go
+++ b/src/stackdriver-nozzle/metrics_pipeline/router_test.go
@@ -25,12 +25,11 @@ var _ = Describe("Router", func() {
 		logEvent := events.Envelope_ValueMetric
 
 		router := NewRouter(metricAdapter, []events.Envelope_EventType{metricEvent}, logAdapter, []events.Envelope_EventType{logEvent})
-		err := router.PostMetricEvents([]*messages.MetricEvent{
+		router.PostMetricEvents([]*messages.MetricEvent{
 			{Type: metricEvent},
 			{Type: logEvent},
 		})
 
-		Expect(err).NotTo(HaveOccurred())
 		Expect(metricAdapter.PostedMetricEvents).To(HaveLen(1))
 		Expect(metricAdapter.PostMetricEventsCount).To(Equal(1))
 		Expect(metricAdapter.PostedMetricEvents[0].Type).To(Equal(metricEvent))
@@ -44,12 +43,11 @@ var _ = Describe("Router", func() {
 		events := []events.Envelope_EventType{metricEvent, logEvent}
 
 		router := NewRouter(metricAdapter, events, logAdapter, events)
-		err := router.PostMetricEvents([]*messages.MetricEvent{
+		router.PostMetricEvents([]*messages.MetricEvent{
 			{Type: metricEvent},
 			{Type: logEvent},
 		})
 
-		Expect(err).NotTo(HaveOccurred())
 		Expect(metricAdapter.PostedMetricEvents).To(HaveLen(2))
 		Expect(metricAdapter.PostMetricEventsCount).To(Equal(1))
 		Expect(metricAdapter.PostedMetricEvents[0].Type).To(Equal(metricEvent))

--- a/src/stackdriver-nozzle/mocks/metric_adapter.go
+++ b/src/stackdriver-nozzle/mocks/metric_adapter.go
@@ -26,23 +26,21 @@ type MetricAdapter struct {
 	sync.Mutex
 
 	PostMetricEventsFn    func(metrics []*messages.MetricEvent) error
-	PostMetricEventsError error
 	PostMetricEventsCount int
 	PostedMetricEvents    []*messages.MetricEvent
 }
 
-func (m *MetricAdapter) PostMetricEvents(events []*messages.MetricEvent) error {
+func (m *MetricAdapter) PostMetricEvents(events []*messages.MetricEvent) {
 	m.Lock()
 	defer m.Unlock()
 
 	m.PostMetricEventsCount += 1
 
 	if m.PostMetricEventsFn != nil {
-		return m.PostMetricEventsFn(events)
+		m.PostMetricEventsFn(events)
 	}
 
 	m.PostedMetricEvents = append(m.PostedMetricEvents, events...)
-	return m.PostMetricEventsError
 }
 
 func (m *MetricAdapter) GetPostedMetricEvents() []*messages.MetricEvent {

--- a/src/stackdriver-nozzle/mocks/metric_client.go
+++ b/src/stackdriver-nozzle/mocks/metric_client.go
@@ -10,6 +10,7 @@ import (
 type MockClient struct {
 	Mutex          sync.Mutex
 	MetricReqs     []*monitoringpb.CreateTimeSeriesRequest
+	TimeSeries     []*monitoringpb.TimeSeries
 	DescriptorReqs []*monitoringpb.CreateMetricDescriptorRequest
 	ListErr        error
 
@@ -24,6 +25,7 @@ func (mc *MockClient) Post(req *monitoringpb.CreateTimeSeriesRequest) error {
 
 	mc.Mutex.Lock()
 	mc.MetricReqs = append(mc.MetricReqs, req)
+	mc.TimeSeries = append(mc.TimeSeries, req.TimeSeries...)
 	mc.Mutex.Unlock()
 
 	return nil

--- a/src/stackdriver-nozzle/mocks/metrics_buffer.go
+++ b/src/stackdriver-nozzle/mocks/metrics_buffer.go
@@ -22,14 +22,12 @@ type MetricsBuffer struct {
 	PostedMetrics []messages.Metric
 }
 
-func (m *MetricsBuffer) PostMetricEvents(events []*messages.MetricEvent) error {
+func (m *MetricsBuffer) PostMetricEvents(events []*messages.MetricEvent) {
 	for _, event := range events {
 		for _, metric := range event.Metrics {
 			m.PostedMetrics = append(m.PostedMetrics, *metric)
 		}
 	}
-
-	return nil
 }
 
 func (m *MetricsBuffer) IsEmpty() bool {

--- a/src/stackdriver-nozzle/mocks/sink.go
+++ b/src/stackdriver-nozzle/mocks/sink.go
@@ -24,16 +24,14 @@ import (
 
 type Sink struct {
 	HandledEnvelopes []events.Envelope
-	Error            error
 	mutex            sync.Mutex
 }
 
-func (s *Sink) Receive(envelope *events.Envelope) error {
+func (s *Sink) Receive(envelope *events.Envelope) {
 	s.mutex.Lock()
-	s.HandledEnvelopes = append(s.HandledEnvelopes, *envelope)
-	s.mutex.Unlock()
+	defer s.mutex.Unlock()
 
-	return s.Error
+	s.HandledEnvelopes = append(s.HandledEnvelopes, *envelope)
 }
 
 func (s *Sink) LastEnvelope() *events.Envelope {

--- a/src/stackdriver-nozzle/nozzle/filter_sink.go
+++ b/src/stackdriver-nozzle/nozzle/filter_sink.go
@@ -25,9 +25,8 @@ func NewFilterSink(eventNames []events.Envelope_EventType, destination Sink) (Si
 	return f, nil
 }
 
-func (sf *filter) Receive(event *events.Envelope) error {
+func (sf *filter) Receive(event *events.Envelope) {
 	if sf.enabled[event.GetEventType()] {
-		return sf.destination.Receive(event)
+		sf.destination.Receive(event)
 	}
-	return nil
 }

--- a/src/stackdriver-nozzle/nozzle/filter_sink_test.go
+++ b/src/stackdriver-nozzle/nozzle/filter_sink_test.go
@@ -45,7 +45,7 @@ var _ = Describe("SinkFilter", func() {
 		eventType := events.Envelope_LogMessage
 		event := events.Envelope{EventType: &eventType}
 
-		Expect(f.Receive(&event)).NotTo(HaveOccurred())
+		f.Receive(&event)
 		Expect(sink.HandledEnvelopes).To(ContainElement(event))
 
 	})

--- a/src/stackdriver-nozzle/nozzle/log_sink.go
+++ b/src/stackdriver-nozzle/nozzle/log_sink.go
@@ -42,7 +42,7 @@ type logSink struct {
 	newlineToken string
 }
 
-func (ls *logSink) Receive(envelope *events.Envelope) (err error) {
+func (ls *logSink) Receive(envelope *events.Envelope) {
 	if envelope == nil {
 		// This happens when we get a fatal error from firehose,
 		// It also happens a few thousand times in a row.
@@ -51,8 +51,6 @@ func (ls *logSink) Receive(envelope *events.Envelope) (err error) {
 	}
 	log := ls.parseEnvelope(envelope)
 	ls.logAdapter.PostLog(&log)
-
-	return
 }
 
 func structToMap(obj interface{}) map[string]interface{} {

--- a/src/stackdriver-nozzle/nozzle/metric_sink.go
+++ b/src/stackdriver-nozzle/nozzle/metric_sink.go
@@ -90,7 +90,9 @@ func (ms *metricSink) Receive(envelope *events.Envelope) error {
 		return fmt.Errorf("unknown event type: %v", envelope.EventType)
 	}
 
-	return ms.metricAdapter.PostMetricEvents([]*messages.MetricEvent{
+	ms.metricAdapter.PostMetricEvents([]*messages.MetricEvent{
 		{Metrics: metrics, Labels: labels, Type: envelope.GetEventType()},
 	})
+
+	return nil
 }

--- a/src/stackdriver-nozzle/nozzle/sink.go
+++ b/src/stackdriver-nozzle/nozzle/sink.go
@@ -19,5 +19,5 @@ package nozzle
 import "github.com/cloudfoundry/sonde-go/events"
 
 type Sink interface {
-	Receive(*events.Envelope) error
+	Receive(*events.Envelope)
 }

--- a/src/stackdriver-nozzle/stackdriver/metric_adapter.go
+++ b/src/stackdriver-nozzle/stackdriver/metric_adapter.go
@@ -18,6 +18,7 @@ package stackdriver
 
 import (
 	"fmt"
+	"math"
 	"path"
 	"strings"
 	"sync"
@@ -119,7 +120,7 @@ func (ma *metricAdapter) PostMetricEvents(events []*messages.MetricEvent) error 
 	projectName := path.Join("projects", ma.projectID)
 
 	count := len(series)
-	chunks := count/ma.batchSize + 1
+	chunks := int(math.Ceil(float64(count) / float64(ma.batchSize)))
 
 	ma.logger.Info("autoCulledMetricsBuffer", lager.Data{"info": fmt.Sprintf("%v metrics will be flushed in %v batches", count, chunks)})
 	var low, high int

--- a/src/stackdriver-nozzle/stackdriver/metric_adapter.go
+++ b/src/stackdriver-nozzle/stackdriver/metric_adapter.go
@@ -122,7 +122,7 @@ func (ma *metricAdapter) PostMetricEvents(events []*messages.MetricEvent) error 
 	count := len(series)
 	chunks := int(math.Ceil(float64(count) / float64(ma.batchSize)))
 
-	ma.logger.Info("autoCulledMetricsBuffer", lager.Data{"info": fmt.Sprintf("%v metrics will be flushed in %v batches", count, chunks)})
+	ma.logger.Info("metricAdapter.PostMetricEvents", lager.Data{"info": "Posting TimeSeries to Stackdriver", "count": count, "chunks": chunks})
 	var low, high int
 	for i := 0; i < chunks; i++ {
 		low = i * ma.batchSize

--- a/src/stackdriver-nozzle/stackdriver/metric_adapter_test.go
+++ b/src/stackdriver-nozzle/stackdriver/metric_adapter_test.go
@@ -128,7 +128,7 @@ var _ = Describe("MetricAdapter", func() {
 			Expect(client.TimeSeries).To(HaveLen(t.groupSize * 2))
 		},
 		Entry("less than the batch size", batchSizeCase{1, 1}),
-		XEntry("exactly the batch size", batchSizeCase{100, 1}),
+		Entry("exactly the batch size", batchSizeCase{100, 1}),
 		Entry("two over the batch size", batchSizeCase{101, 2}),
 		Entry("a large batch size", batchSizeCase{2001, 21}))
 

--- a/src/stackdriver-nozzle/stackdriver/metric_adapter_test.go
+++ b/src/stackdriver-nozzle/stackdriver/metric_adapter_test.go
@@ -43,12 +43,14 @@ var _ = Describe("MetricAdapter", func() {
 		subject     stackdriver.MetricAdapter
 		client      *mocks.MockClient
 		heartbeater *mocks.Heartbeater
+		logger      *mocks.MockLogger
 	)
 
 	BeforeEach(func() {
 		client = &mocks.MockClient{}
 		heartbeater = mocks.NewHeartbeater()
-		subject, _ = stackdriver.NewMetricAdapter("my-awesome-project", client, batchSize, heartbeater)
+		logger = &mocks.MockLogger{}
+		subject, _ = stackdriver.NewMetricAdapter("my-awesome-project", client, batchSize, heartbeater, logger)
 	})
 
 	It("takes metrics and posts a time series", func() {
@@ -237,7 +239,7 @@ var _ = Describe("MetricAdapter", func() {
 	It("returns the adapter even if we fail to list the metric descriptors", func() {
 		expectedErr := errors.New("fail")
 		client.ListErr = expectedErr
-		subject, err := stackdriver.NewMetricAdapter("my-awesome-project", client, 1, heartbeater)
+		subject, err := stackdriver.NewMetricAdapter("my-awesome-project", client, 1, heartbeater, logger)
 		Expect(subject).To(Not(BeNil()))
 		Expect(err).To(Equal(expectedErr))
 	})

--- a/src/stackdriver-nozzle/stackdriver/metric_adapter_test.go
+++ b/src/stackdriver-nozzle/stackdriver/metric_adapter_test.go
@@ -250,12 +250,12 @@ var _ = Describe("MetricAdapter", func() {
 				},
 			}}}
 
-		Expect(subject.PostMetricEvents(metricEvents)).To(Succeed())
+		subject.PostMetricEvents(metricEvents)
 		Expect(heartbeater.GetCount("metrics.events.count")).To(Equal(2))
 		Expect(heartbeater.GetCount("metrics.timeseries.count")).To(Equal(3))
 		Expect(heartbeater.GetCount("metrics.requests")).To(Equal(1))
 
-		Expect(subject.PostMetricEvents(metricEvents)).To(Succeed())
+		subject.PostMetricEvents(metricEvents)
 		Expect(heartbeater.GetCount("metrics.events.count")).To(Equal(4))
 		Expect(heartbeater.GetCount("metrics.timeseries.count")).To(Equal(6))
 		Expect(heartbeater.GetCount("metrics.requests")).To(Equal(2))
@@ -268,7 +268,7 @@ var _ = Describe("MetricAdapter", func() {
 			return errors.New("GRPC Stuff. Points must be written in order. Other stuff")
 		}
 
-		Expect(subject.PostMetricEvents(metricEvents)).To(Succeed())
+		subject.PostMetricEvents(metricEvents)
 		Expect(heartbeater.GetCount("metrics.post.errors")).To(Equal(1))
 		Expect(heartbeater.GetCount("metrics.post.errors.out_of_order")).To(Equal(1))
 		Expect(heartbeater.GetCount("metrics.post.errors.unknown")).To(Equal(0))
@@ -280,7 +280,7 @@ var _ = Describe("MetricAdapter", func() {
 		client.PostFn = func(req *monitoringpb.CreateTimeSeriesRequest) error {
 			return errors.New("tragedy strikes")
 		}
-		Expect(subject.PostMetricEvents(metricEvents)).NotTo(Succeed())
+		subject.PostMetricEvents(metricEvents)
 		Expect(heartbeater.GetCount("metrics.post.errors")).To(Equal(1))
 		Expect(heartbeater.GetCount("metrics.post.errors.out_of_order")).To(Equal(0))
 		Expect(heartbeater.GetCount("metrics.post.errors.unknown")).To(Equal(1))

--- a/tile.yml.erb
+++ b/tile.yml.erb
@@ -38,7 +38,7 @@ packages:
         project_id: (( .properties.project_id.value ))
       nozzle:
         metrics_buffer_duration: (( .properties.metrics_buffer_duration.value ))
-        metrics_buffer_size: (( .properties.metrics_buffer_size.value ))
+        metrics_batch_size: (( .properties.metrics_batch_size.value ))
 
 
 forms:
@@ -86,7 +86,7 @@ forms:
     type: integer
     default: 30
     description: Flush interval (in seconds) of the internal metric buffer
-  - name: metrics_buffer_size
+  - name: metrics_batch_size
     type: integer
     default: 200
     description: Batch size for time series being sent to Stackdriver


### PR DESCRIPTION
Move batching down the pipeline so we can do it at the `TimeSeries` level. The `AutoCullingMetricsBuffer` can't accurately batch because it deals in `MetricEvent` which may result in multiple `TimeSeries`. Plus it's not the `AutoCullingMetricsBatchingBuffer` is it? 

This change moves out the Stackdriver implementation behavior of sending 200 or less time series per request into the `MetricAdapter`

Fixes #137

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cloudfoundry-community/stackdriver-tools/143)
<!-- Reviewable:end -->
