### PR TITLE
 Config options for metric prefix and director name.

### DIFF
--- a/jobs/stackdriver-nozzle/spec
+++ b/jobs/stackdriver-nozzle/spec
@@ -51,3 +51,11 @@ properties:
   nozzle.resolve_app_metadata:
     description: Enable resolution of app metadata from appGuid
     default: true
+
+  nozzle.metric_path_prefix
+    description: Prefix added to all metric names being sent to Stackdriver, e.g. 'custom/PREFIX/gorouter.total_requests'. May contain slashes.
+    default: firehose
+
+  nozzle.bosh_director_name
+    description: Name added as the 'director' label to all time series being sent to Stackdriver, useful for differentiating between multiple PCF instances in a project.
+    default: cf

--- a/jobs/stackdriver-nozzle/templates/stackdriver-nozzle-ctl.erb
+++ b/jobs/stackdriver-nozzle/templates/stackdriver-nozzle-ctl.erb
@@ -34,6 +34,8 @@ case $1 in
     export RESOLVE_APP_METADATA=<%= p('nozzle.resolve_app_metadata', 'true') %>
     export METRICS_BUFFER_DURATION=<%= p('nozzle.metrics_buffer_duration', '30') %>
     export METRICS_BATCH_SIZE=<%= p('nozzle.metrics_batch_size', '200') %>
+    export METRIC_PATH_PREFIX=<%= p('nozzle.metric_path_prefix', 'firehose') %>
+    export BOSH_DIRECTOR_NAME=<%= p('nozzle.bosh_director_name', 'cf') %>
 
     <% if_p('gcp.project_id') do |prop| %>
     export GCP_PROJECT_ID=<%= prop %>

--- a/src/stackdriver-nozzle/README.md
+++ b/src/stackdriver-nozzle/README.md
@@ -39,6 +39,10 @@ go get github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-nozzl
 
 #### Nozzle
 
+- `BOSH_DIRECTOR_NAME` - sets the value of the "director" label added to every
+  metric / log exported to Stackdriver; defaults to "cf". This is useful for
+  differentiating between multiple cloud foundry / BOSH instances in the same
+  GCP / Stackdriver project.
 - `HEARTBEAT_RATE` - how often `stackdriver-nozzle` reports stats to stdout;
   defaults to 30 seconds
 - `LOGGING_BATCH_COUNT` - how many logs to batch into a single report to
@@ -49,6 +53,10 @@ go get github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-nozzl
   buffer; defaults to 30
 - `METRICS_BATCH_SIZE` - batch size for metric time series being sent to
   Stackdriver; defaults to 200
+- `METRIC_PATH_PREFIX` - sets a prefix for all custom metrics exported to
+  Stackdriver, e.g. custom.googleapis.com/PREFIX/gorouter.total_requests;
+  defaults to "firehose". May contain slashes. Useful to "namespace"
+  cloud foundry metrics from others in the same Stackdriver project.
 - `RESOLVE_APP_METADATA` - whether to hydrate app UUIDs into org name, org
   UUID, space name, space UUID, and app name; defaults to `true`
 - `SUBSCRIPTION_ID` - what subscription ID to use for connecting to the

--- a/src/stackdriver-nozzle/app/builder.go
+++ b/src/stackdriver-nozzle/app/builder.go
@@ -70,7 +70,7 @@ func New(c *config.Config, logger lager.Logger) *App {
 	} else {
 		appInfoRepository = cloudfoundry.NullAppInfoRepository()
 	}
-	labelMaker := nozzle.NewLabelMaker(appInfoRepository)
+	labelMaker := nozzle.NewLabelMaker(appInfoRepository, c.BoshDirectorName)
 
 	return &App{
 		logger:      logger,
@@ -152,5 +152,5 @@ func (a *App) newMetricSink(ctx context.Context, metricAdapter stackdriver.Metri
 	metricBuffer := metrics_pipeline.NewAutoCulledMetricsBuffer(ctx, a.logger, time.Duration(a.c.MetricsBufferDuration)*time.Second, metricAdapter, a.heartbeater)
 	a.bufferEmpty = metricBuffer.IsEmpty
 
-	return nozzle.NewMetricSink(a.logger, a.labelMaker, metricBuffer, nozzle.NewUnitParser())
+	return nozzle.NewMetricSink(a.logger, a.c.MetricPathPrefix, a.labelMaker, metricBuffer, nozzle.NewUnitParser())
 }

--- a/src/stackdriver-nozzle/config/config.go
+++ b/src/stackdriver-nozzle/config/config.go
@@ -65,6 +65,8 @@ type Config struct {
 	HeartbeatRate         int    `envconfig:"heartbeat_rate" default:"30"`
 	MetricsBufferDuration int    `envconfig:"metrics_buffer_duration" default:"30"`
 	MetricsBatchSize      int    `envconfig:"metrics_batch_size" default:"200"`
+	MetricPathPrefix      string `envconfig:"metric_path_prefix" default:"firehose"`
+	BoshDirectorName      string `envconfig:"bosh_director_name" default:"cf"`
 	ResolveAppMetadata    bool   `envconfig:"resolve_app_metadata"`
 	NozzleId              string `envconfig:"nozzle_id" default:"local-nozzle"`
 	NozzleName            string `envconfig:"nozzle_name" default:"local-nozzle"`

--- a/src/stackdriver-nozzle/nozzle/label_maker.go
+++ b/src/stackdriver-nozzle/nozzle/label_maker.go
@@ -32,12 +32,16 @@ type LabelMaker interface {
 	LogLabels(*events.Envelope) map[string]string
 }
 
-func NewLabelMaker(appInfoRepository cloudfoundry.AppInfoRepository) LabelMaker {
-	return &labelMaker{appInfoRepository: appInfoRepository}
+func NewLabelMaker(appInfoRepository cloudfoundry.AppInfoRepository, directorName string) LabelMaker {
+	return &labelMaker{
+		appInfoRepository: appInfoRepository,
+		directorName:      directorName,
+	}
 }
 
 type labelMaker struct {
 	appInfoRepository cloudfoundry.AppInfoRepository
+	directorName      string
 }
 
 type labelMap map[string]string
@@ -77,6 +81,7 @@ func (pm *pathMaker) String() string {
 func (lm *labelMaker) MetricLabels(envelope *events.Envelope) map[string]string {
 	labels := labelMap{}
 
+	labels.setIfNotEmpty("director", lm.directorName)
 	labels.setIfNotEmpty("job", envelope.GetJob())
 	labels.setIfNotEmpty("index", envelope.GetIndex())
 	labels.setIfNotEmpty("applicationPath", lm.getApplicationPath(envelope))

--- a/src/stackdriver-nozzle/nozzle/label_maker_test.go
+++ b/src/stackdriver-nozzle/nozzle/label_maker_test.go
@@ -28,6 +28,8 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+const director = "bosh-director"
+
 var _ = Describe("LabelMaker", func() {
 	var (
 		subject  nozzle.LabelMaker
@@ -35,7 +37,7 @@ var _ = Describe("LabelMaker", func() {
 	)
 
 	BeforeEach(func() {
-		subject = nozzle.NewLabelMaker(cloudfoundry.NullAppInfoRepository())
+		subject = nozzle.NewLabelMaker(cloudfoundry.NullAppInfoRepository(), director)
 	})
 
 	It("makes labels from envelopes", func() {
@@ -66,11 +68,13 @@ var _ = Describe("LabelMaker", func() {
 		logLabels := subject.LogLabels(envelope)
 
 		Expect(metricLabels).To(Equal(map[string]string{
-			"job":   job,
-			"index": index,
-			"tags":  "bar=foo,foo=bar",
+			"director": director,
+			"job":      job,
+			"index":    index,
+			"tags":     "bar=foo,foo=bar",
 		}))
 		Expect(logLabels).To(Equal(map[string]string{
+			"director":  director,
 			"job":       job,
 			"index":     index,
 			"tags":      "bar=foo,foo=bar",
@@ -103,9 +107,10 @@ var _ = Describe("LabelMaker", func() {
 		labels := subject.MetricLabels(envelope)
 
 		Expect(labels).To(Equal(map[string]string{
-			"job":   job,
-			"index": index,
-			"tags":  "foo=bar",
+			"director": director,
+			"job":      job,
+			"index":    index,
+			"tags":     "foo=bar",
 		}))
 	})
 
@@ -126,7 +131,7 @@ var _ = Describe("LabelMaker", func() {
 				appInfoRepository = &mocks.AppInfoRepository{
 					AppInfoMap: map[string]cloudfoundry.AppInfo{},
 				}
-				subject = nozzle.NewLabelMaker(appInfoRepository)
+				subject = nozzle.NewLabelMaker(appInfoRepository, director)
 			})
 
 			Context("for a LogMessage", func() {

--- a/src/stackdriver-nozzle/nozzle/metric_sink_test.go
+++ b/src/stackdriver-nozzle/nozzle/metric_sink_test.go
@@ -55,7 +55,7 @@ var _ = Describe("MetricSink", func() {
 		unitParser = &mockUnitParser{}
 		logger = &mocks.MockLogger{}
 
-		subject = nozzle.NewMetricSink(logger, labelMaker, metricBuffer, unitParser)
+		subject = nozzle.NewMetricSink(logger, "firehose", labelMaker, metricBuffer, unitParser)
 	})
 
 	It("creates metric for ValueMetric", func() {
@@ -85,7 +85,7 @@ var _ = Describe("MetricSink", func() {
 		metrics := metricBuffer.PostedMetrics
 		Expect(metrics).To(HaveLen(1))
 		Expect(metrics[0]).To(MatchAllFields(Fields{
-			"Name":      Equal("origin.valueMetricName"),
+			"Name":      Equal("firehose/origin.valueMetricName"),
 			"Value":     Equal(123.456),
 			"EventTime": Ignore(),
 			"Unit":      Equal("{foo}"),
@@ -136,12 +136,12 @@ var _ = Describe("MetricSink", func() {
 		}
 
 		Expect(metrics).To(MatchAllElements(eventName, Elements{
-			"origin.diskBytesQuota":   MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(1073741824)), "EventTime": Ignore(), "Unit": Equal("")}),
-			"origin.instanceIndex":    MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(0)), "EventTime": Ignore(), "Unit": Equal("")}),
-			"origin.cpuPercentage":    MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(0.061651273460637)), "EventTime": Ignore(), "Unit": Equal("")}),
-			"origin.diskBytes":        MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(164634624)), "EventTime": Ignore(), "Unit": Equal("")}),
-			"origin.memoryBytes":      MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(16601088)), "EventTime": Ignore(), "Unit": Equal("")}),
-			"origin.memoryBytesQuota": MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(33554432)), "EventTime": Ignore(), "Unit": Equal("")}),
+			"firehose/origin.diskBytesQuota":   MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(1073741824)), "EventTime": Ignore(), "Unit": Equal("")}),
+			"firehose/origin.instanceIndex":    MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(0)), "EventTime": Ignore(), "Unit": Equal("")}),
+			"firehose/origin.cpuPercentage":    MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(0.061651273460637)), "EventTime": Ignore(), "Unit": Equal("")}),
+			"firehose/origin.diskBytes":        MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(164634624)), "EventTime": Ignore(), "Unit": Equal("")}),
+			"firehose/origin.memoryBytes":      MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(16601088)), "EventTime": Ignore(), "Unit": Equal("")}),
+			"firehose/origin.memoryBytesQuota": MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(33554432)), "EventTime": Ignore(), "Unit": Equal("")}),
 		}))
 	})
 
@@ -175,13 +175,13 @@ var _ = Describe("MetricSink", func() {
 			return element.(messages.Metric).Name
 		}
 		Expect(metrics).To(MatchAllElements(eventName, Elements{
-			"origin.counterName.delta": MatchAllFields(Fields{
+			"firehose/origin.counterName.delta": MatchAllFields(Fields{
 				"Name":      Ignore(),
 				"Value":     Equal(float64(654321)),
 				"EventTime": Ignore(),
 				"Unit":      Equal(""),
 			}),
-			"origin.counterName.total": MatchAllFields(Fields{
+			"firehose/origin.counterName.total": MatchAllFields(Fields{
 				"Name":      Ignore(),
 				"Value":     Equal(float64(123456)),
 				"EventTime": Ignore(),

--- a/tile.yml.erb
+++ b/tile.yml.erb
@@ -39,6 +39,8 @@ packages:
       nozzle:
         metrics_buffer_duration: (( .properties.metrics_buffer_duration.value ))
         metrics_batch_size: (( .properties.metrics_batch_size.value ))
+        metric_path_prefix: (( .properties.metric_path_prefix.value ))
+        bosh_director_name: (( .properties.bosh_director_name.value ))
 
 
 forms:
@@ -90,3 +92,11 @@ forms:
     type: integer
     default: 200
     description: Batch size for time series being sent to Stackdriver
+  - name: metric_path_prefix
+    type: string
+    default: firehose
+    description: Prefix added to all metric names being sent to Stackdriver, e.g. 'custom/PREFIX/gorouter.total_requests'. May contain slashes.
+  - name: bosh_director_name
+    type: string
+    default: cf
+    description: Name added as the 'director' label to all time series being sent to Stackdriver, useful for differentiating between multiple PCF instances in a project.


### PR DESCRIPTION
The nozzle currently places all the metrics it derives from firehose
data in the root of Stackdriver's custom metric namespace. This means
there's a relatively large chance that these names could collide with
others that were not created by the nozzle. To mitigate this, a config
option "metric_path_prefix" (that defaults to "firehose") is added.
After this commit, Stackdriver metric names will be of the form:

    custom.googleapis.com/PREFIX/origin.Name
    custom.googleapis.com/firehose/gorouter.total_requests

Running multiple PCF instances in the same GCP project will result in
metrics from all instances being confused with each other. Since the
nozzle runs on BOSH, another config option "bosh_director_name" (that
defaults to "cf") has been added. This sets the value of a static
"director" label added to every metric exported by the nozzle. Setting
this to different values for each PCF instance in a project (e.g. the
 GCP region, if running one PCF instance per region) allows PCF metrics
to be distinguished from one another.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cloudfoundry-community/stackdriver-tools/144)
<!-- Reviewable:end -->
