### PR TITLE
nozzle/metric_sink: remove instanceIndex metric

### DIFF
--- a/src/stackdriver-nozzle/nozzle/metric_sink.go
+++ b/src/stackdriver-nozzle/nozzle/metric_sink.go
@@ -83,7 +83,6 @@ func (ms *metricSink) Receive(envelope *events.Envelope) {
 		containerMetric := envelope.GetContainerMetric()
 		metrics = []*messages.Metric{
 			{Name: metricPrefix + "diskBytesQuota", Value: float64(containerMetric.GetDiskBytesQuota()), EventTime: eventTime},
-			{Name: metricPrefix + "instanceIndex", Value: float64(containerMetric.GetInstanceIndex()), EventTime: eventTime},
 			{Name: metricPrefix + "cpuPercentage", Value: float64(containerMetric.GetCpuPercentage()), EventTime: eventTime},
 			{Name: metricPrefix + "diskBytes", Value: float64(containerMetric.GetDiskBytes()), EventTime: eventTime},
 			{Name: metricPrefix + "memoryBytes", Value: float64(containerMetric.GetMemoryBytes()), EventTime: eventTime},

--- a/src/stackdriver-nozzle/nozzle/metric_sink_test.go
+++ b/src/stackdriver-nozzle/nozzle/metric_sink_test.go
@@ -137,7 +137,6 @@ var _ = Describe("MetricSink", func() {
 
 		Expect(metrics).To(MatchAllElements(eventName, Elements{
 			"firehose/origin.diskBytesQuota":   MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(1073741824)), "EventTime": Ignore(), "Unit": Equal("")}),
-			"firehose/origin.instanceIndex":    MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(0)), "EventTime": Ignore(), "Unit": Equal("")}),
 			"firehose/origin.cpuPercentage":    MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(0.061651273460637)), "EventTime": Ignore(), "Unit": Equal("")}),
 			"firehose/origin.diskBytes":        MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(164634624)), "EventTime": Ignore(), "Unit": Equal("")}),
 			"firehose/origin.memoryBytes":      MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(16601088)), "EventTime": Ignore(), "Unit": Equal("")}),


### PR DESCRIPTION
This isn't a metric, it's a label as repoted by #100. We now properly
emit it as a label as of #136.

This change is simply cleanup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cloudfoundry-community/stackdriver-tools/145)
<!-- Reviewable:end -->
