### PR TITLE
cmd/clear-metric-descriptors: fix for api change

### DIFF
--- a/src/stackdriver-nozzle/cmd/clear-metrics-descriptors.go
+++ b/src/stackdriver-nozzle/cmd/clear-metrics-descriptors.go
@@ -22,6 +22,7 @@ import (
 
 	"cloud.google.com/go/monitoring/apiv3"
 	"golang.org/x/net/context"
+	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
 )
@@ -42,7 +43,7 @@ func main() {
 	it := metricClient.ListMetricDescriptors(ctx, req)
 	for {
 		resp, err := it.Next()
-		if err == monitoring.Done {
+		if err == iterator.Done {
 			break
 		}
 		if err != nil {


### PR DESCRIPTION
the stackdriver API uses the standardized iterator.Done instead of a
monitoring specific .Done

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cloudfoundry-community/stackdriver-tools/146)
<!-- Reviewable:end -->
