### PR TITLE
stackdriver-nozzle/tile: debugging options, logging configuration

### DIFF
--- a/jobs/stackdriver-nozzle/spec
+++ b/jobs/stackdriver-nozzle/spec
@@ -44,6 +44,14 @@ properties:
     description: Batch size for time series being sent to Stackdriver
     default: 200
 
+  nozzle.logging_batch_count:
+    description: Batch size for log messages being sent to Stackdriver
+    default: 1000
+
+ nozzle.logging_batch_duration:
+    description: Flush interval (in seconds) of the internal logging buffer
+    default: 30
+
   nozzle.debug:
     description: Enable debug features for the stackdriver-nozzle for development or troubleshooting
     default: false

--- a/jobs/stackdriver-nozzle/templates/stackdriver-nozzle-ctl.erb
+++ b/jobs/stackdriver-nozzle/templates/stackdriver-nozzle-ctl.erb
@@ -36,6 +36,8 @@ case $1 in
     export METRICS_BATCH_SIZE=<%= p('nozzle.metrics_batch_size', '200') %>
     export METRIC_PATH_PREFIX=<%= p('nozzle.metric_path_prefix', 'firehose') %>
     export BOSH_DIRECTOR_NAME=<%= p('nozzle.bosh_director_name', 'cf') %>
+    export LOGGING_BATCH_COUNT=<%= p('nozzle.logging_batch_count', '1000') %>
+    export LOGGING_BATCH_DURATION=<= p('nozzle.logging_batch_duration', '30') %>
 
     <% if_p('gcp.project_id') do |prop| %>
     export GCP_PROJECT_ID=<%= prop %>

--- a/src/stackdriver-nozzle/app/runner.go
+++ b/src/stackdriver-nozzle/app/runner.go
@@ -25,7 +25,7 @@ func Run(ctx context.Context, a *App) {
 
 		go func() {
 			a.logger.Info("pprof", lager.Data{
-				"http.ListenAndServe": http.ListenAndServe("localhost:6060", nil),
+				"http.ListenAndServe": http.ListenAndServe("0.0.0.0:6060", nil),
 			})
 		}()
 	}

--- a/src/stackdriver-nozzle/config/config.go
+++ b/src/stackdriver-nozzle/config/config.go
@@ -58,8 +58,8 @@ type Config struct {
 
 	// Stackdriver config
 	ProjectID            string `envconfig:"gcp_project_id"`
-	LoggingBatchCount    int    `envconfig:"logging_batch_count" default:"10"`
-	LoggingBatchDuration int    `envconfig:"logging_batch_duration" default:"1"`
+	LoggingBatchCount    int    `envconfig:"logging_batch_count" default:"1000"`
+	LoggingBatchDuration int    `envconfig:"logging_batch_duration" default:"30"`
 
 	// Nozzle config
 	HeartbeatRate         int    `envconfig:"heartbeat_rate" default:"30"`

--- a/tile.yml.erb
+++ b/tile.yml.erb
@@ -41,6 +41,9 @@ packages:
         metrics_batch_size: (( .properties.metrics_batch_size.value ))
         metric_path_prefix: (( .properties.metric_path_prefix.value ))
         bosh_director_name: (( .properties.bosh_director_name.value ))
+        logging_batch_count: (( .properties.logging_batch_count.value ))
+        logging_batch_duration: (( .properties.logging_batch_duration.value ))
+        debug: (( .properties.debug.value ))
 
 
 forms:
@@ -87,16 +90,34 @@ forms:
   - name: metrics_buffer_duration
     type: integer
     default: 30
+    label: Metrics Buffer Duration
     description: Flush interval (in seconds) of the internal metric buffer
   - name: metrics_batch_size
     type: integer
     default: 200
+    label: Metrics Batch Size
     description: Batch size for time series being sent to Stackdriver
+  - name: logging_batch_duration
+    type: integer
+    default: 30
+    label: Logging Buffer Duration
+    description: Flush interval (in seconds) of the internal logging buffer
+  - name: logging_batch_count
+    default: 1000
+    label: Logging Batch Count
+    description: Batch size for log messages being sent to Stackdriver
   - name: metric_path_prefix
     type: string
     default: firehose
+    label: Metric Path Prefix
     description: Prefix added to all metric names being sent to Stackdriver, e.g. 'custom/PREFIX/gorouter.total_requests'. May contain slashes.
   - name: bosh_director_name
     type: string
     default: cf
+    label: Bosh Director Name
     description: Name added as the 'director' label to all time series being sent to Stackdriver, useful for differentiating between multiple PCF instances in a project.
+  - name: debug
+    type: boolean
+    default: false
+    label: Nozzle Debugging
+    description: Enable Nozzle Debugging Features. With this enabled each Stackdriver Nozzle instance will host a web server on 0.0.0.0:6060 that exposes debug information such as a heap dump and running threads.


### PR DESCRIPTION
- Expose `NOZZLE_DEBUG` setting to allow for pprof access on the hosted
  nozzle (http://<VM>:6060/debug/pprof/). This also enables Stackdriver Error reporting for crashes. Fixes #114
- Expose Logging buffer duration/size settings and update default to a more reasonable value
- Add Labels for recently added options in the tile for better presentation. At some point we'll want to separate these settings into logical pages now that the options are getting long.

/cc @knyar @fluffle

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cloudfoundry-community/stackdriver-tools/147)
<!-- Reviewable:end -->
