### PR TITLE
Revert "ci: use gcs blobstore"

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,56 +1,56 @@
 golang/go1.9.linux-amd64.tar.gz:
   size: 102601309
-  object_id: 160497b1-2af4-45f1-58aa-33ad330d7bd2
+  object_id: 9389191f-2e77-4df2-6ccd-d4a1639ed201
   sha: 6a00c39435edc1e102f1fb75cc1137fba4c9e4e2
 google-fluentd-vendor/google-fluentd-vendor-0.12-plugin-0.5.3.tgz:
   size: 12407170
-  object_id: 79eb8bb1-a528-4167-6507-88c3435fa35c
+  object_id: da306bf9-a23c-46cc-69e7-7e86a54e7bbb
   sha: 8d00c8753e3d98e0e8a56f91acca54eaec88c277
 google-fluentd-vendor/google-fluentd-vendor-0.14.tgz:
   size: 5099520
-  object_id: 0ebe4eaa-bf37-4ba8-6318-5a0ef581f239
+  object_id: ad88f6c7-fd8d-41ae-6109-65e3f604e76f
   sha: 9eb9504e3eef812eac7ea5e5f61a038c893544f4
 libtool/libtool-2.4.2.tar.gz:
   size: 2632347
-  object_id: 03f9a512-454e-4e66-4cca-bce02387e09f
+  object_id: a72448bd-9ae1-482a-54f3-a73f6820c2c4
   sha: 22b71a8b5ce3ad86e1094e7285981cae10e6ff88
 libyajl/yajl-2.1.0.tar.gz:
   size: 84039
-  object_id: f85614c1-64a7-42a7-6dc9-28713381d744
+  object_id: 0a77c971-4860-4059-5bb7-8b3e0049f2ff
   sha: fe6b3c7439b26175aee59cabf8c4923b9eb3650d
 python/Python-2.7.11.tgz:
   size: 16856409
-  object_id: 7b94834b-a667-41af-75d0-bd6f593a9fe4
+  object_id: 5436eeb5-0322-4aff-5eac-a335d0ee2c72
   sha: 62a0b1b703d42999cc4aa9ee3c55eb7efe35802a
 python/netifaces-0.10.4.tar.gz:
   size: 22969
-  object_id: 97326cc7-0085-4c8e-5dd3-3e81d13370ae
+  object_id: 7f3b60f2-f5ad-422e-708e-91d1e49be6f8
   sha: c3fcd491a89c2994815053e853b005e7fc27c79a
 python/psutil-1.2.1.tar.gz:
   size: 167397
-  object_id: 3ae5670e-0c3d-49a8-60da-ff774408c492
+  object_id: 4e341411-e85b-453e-6a01-03b259700b57
   sha: c8c1842bf1c63b9068ac25a37f7aae11fcecd57f
 python/setuptools-20.4.tar.gz:
   size: 675976
-  object_id: 833a44de-734a-4f4a-4600-aa926aecb081
+  object_id: ff2e938d-6ce7-4514-4d9f-a7197564f7af
   sha: b9ffbf5e29765c4a786c7242be1b03bfe08ad1c0
 ruby/bundler-1.10.6.gem:
   size: 251392
-  object_id: 12f8e4c8-a91e-45ff-589d-270cf537d1f8
+  object_id: 810385aa-b9c4-4bb0-6f3b-446772507496
   sha: 55a37fccd1c0cb5542d468e35d3be46dd0667f73
 ruby/ruby-2.3.0.tar.gz:
   size: 17648682
-  object_id: 29ecf333-391c-4cfb-78a4-6356f195acdb
+  object_id: 6b96ba17-ffbe-4d9a-7726-c695c1f4efc4
   sha: 2dfcf7f33bda4078efca30ae28cb89cd0e36ddc4
 ruby/rubygems-2.6.2.tgz:
   size: 478660
-  object_id: 1d009ed5-a47d-476a-7a36-05f98c1a9e57
+  object_id: 90ddc55c-9119-42c7-5c8d-cc610dc5c6d8
   sha: 5960628b1f90f4a05ed69c0ad59c59cb10b79e5f
 ruby/yaml-0.1.6.tar.gz:
   size: 503012
-  object_id: 81440cf0-218e-4f15-6dad-3967057d4d56
+  object_id: fbd1083b-6f50-40d8-452a-d0c351326e40
   sha: f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d
 stackdriver-agent/stackdriver-agent_5.5.2-347.tgz:
   size: 1085047
-  object_id: 58d76e16-407f-4e94-43ae-b44dc4fcf0d6
+  object_id: f748aeb7-e248-4eab-4969-57fd48000575
   sha: 862df2ed4a2558086df9491231068075b2495026

--- a/config/final.yml
+++ b/config/final.yml
@@ -1,6 +1,9 @@
 ---
 final_name: stackdriver-tools
 blobstore:
-  provider: gcs
+  provider: s3
   options:
     bucket_name: stackdriver-tools-blobs
+    host: storage.googleapis.com
+    use_ssl: true
+    endpoint: https://storage.googleapis.com


### PR DESCRIPTION
Native GCS support for developers using the public bucket is blocked on
cloudfoundry/bosh#343 being merged.

This reverts commit f0a39ee3e097afc8c8d9772b430ab4842d372623.

Signed-off-by: Jeff Johnson <jrjohnson@google.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cloudfoundry-community/stackdriver-tools/154)
<!-- Reviewable:end -->
