### PR TITLE
Merge Metric and MetricEvent (#142)

### DIFF
--- a/src/stackdriver-nozzle/messages/metric.go
+++ b/src/stackdriver-nozzle/messages/metric.go
@@ -8,31 +8,24 @@ import (
 	"github.com/cloudfoundry/sonde-go/events"
 )
 
+// Metric represents one of the metrics contained in an events.Envelope.
 type Metric struct {
 	Name      string
+	Labels    map[string]string `json:"-"`
 	Value     float64
 	EventTime time.Time
-	Unit      string // TODO Should this be "1" if it's empty?
+	Unit      string                    // TODO Should this be "1" if it's empty?
+	Type      events.Envelope_EventType `json:"-"`
 }
 
-// MetricEvent represents the translation of an events.Envelope into a set
-// of Metrics
-type MetricEvent struct {
-	Labels  map[string]string `json:"-"`
-	Metrics []*Metric
-	Type    events.Envelope_EventType `json:"-"`
-}
-
-func (m *MetricEvent) Hash() string {
+func (m *Metric) Hash() string {
 	var b bytes.Buffer
 
 	// Extract keys to a slice and sort it
-	numKeys := len(m.Metrics) + len(m.Labels)
+	numKeys := len(m.Labels) + 1
 	keys := make([]string, numKeys, numKeys)
-	for _, m := range m.Metrics {
-		keys = append(keys, m.Name)
-	}
-	for k, _ := range m.Labels {
+	keys = append(keys, m.Name)
+	for k := range m.Labels {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)

--- a/src/stackdriver-nozzle/metrics_pipeline/router.go
+++ b/src/stackdriver-nozzle/metrics_pipeline/router.go
@@ -31,23 +31,23 @@ func NewRouter(metricAdapter stackdriver.MetricAdapter, metricEvents []events.En
 	return r
 }
 
-func (r *router) PostMetricEvents(events []*messages.MetricEvent) {
-	metricEvents := []*messages.MetricEvent{}
-	for i := range events {
-		if r.metricEvents[events[i].Type] {
-			metricEvents = append(metricEvents, events[i])
+func (r *router) PostMetrics(metrics []*messages.Metric) {
+	metricEvents := []*messages.Metric{}
+	for i := range metrics {
+		if r.metricEvents[metrics[i].Type] {
+			metricEvents = append(metricEvents, metrics[i])
 		}
 
-		if r.logEvents[events[i].Type] {
+		if r.logEvents[metrics[i].Type] {
 			log := &messages.Log{
-				Labels:  events[i].Labels,
-				Payload: events[i],
+				Labels:  metrics[i].Labels,
+				Payload: metrics[i],
 			}
 			r.logAdapter.PostLog(log)
 		}
 	}
 
 	if len(metricEvents) > 0 {
-		r.metricAdapter.PostMetricEvents(metricEvents)
+		r.metricAdapter.PostMetrics(metricEvents)
 	}
 }

--- a/src/stackdriver-nozzle/metrics_pipeline/router_test.go
+++ b/src/stackdriver-nozzle/metrics_pipeline/router_test.go
@@ -25,16 +25,16 @@ var _ = Describe("Router", func() {
 		logEvent := events.Envelope_ValueMetric
 
 		router := NewRouter(metricAdapter, []events.Envelope_EventType{metricEvent}, logAdapter, []events.Envelope_EventType{logEvent})
-		router.PostMetricEvents([]*messages.MetricEvent{
+		router.PostMetrics([]*messages.Metric{
 			{Type: metricEvent},
 			{Type: logEvent},
 		})
 
-		Expect(metricAdapter.PostedMetricEvents).To(HaveLen(1))
-		Expect(metricAdapter.PostMetricEventsCount).To(Equal(1))
-		Expect(metricAdapter.PostedMetricEvents[0].Type).To(Equal(metricEvent))
+		Expect(metricAdapter.PostedMetrics).To(HaveLen(1))
+		Expect(metricAdapter.PostMetricsCount).To(Equal(1))
+		Expect(metricAdapter.PostedMetrics[0].Type).To(Equal(metricEvent))
 		Expect(logAdapter.PostedLogs).To(HaveLen(1))
-		Expect(logAdapter.PostedLogs[0].Payload.(*messages.MetricEvent).Type).To(Equal(logEvent))
+		Expect(logAdapter.PostedLogs[0].Payload.(*messages.Metric).Type).To(Equal(logEvent))
 	})
 
 	It("can route an event to two locations", func() {
@@ -43,18 +43,18 @@ var _ = Describe("Router", func() {
 		events := []events.Envelope_EventType{metricEvent, logEvent}
 
 		router := NewRouter(metricAdapter, events, logAdapter, events)
-		router.PostMetricEvents([]*messages.MetricEvent{
+		router.PostMetrics([]*messages.Metric{
 			{Type: metricEvent},
 			{Type: logEvent},
 		})
 
-		Expect(metricAdapter.PostedMetricEvents).To(HaveLen(2))
-		Expect(metricAdapter.PostMetricEventsCount).To(Equal(1))
-		Expect(metricAdapter.PostedMetricEvents[0].Type).To(Equal(metricEvent))
-		Expect(metricAdapter.PostedMetricEvents[1].Type).To(Equal(logEvent))
+		Expect(metricAdapter.PostedMetrics).To(HaveLen(2))
+		Expect(metricAdapter.PostMetricsCount).To(Equal(1))
+		Expect(metricAdapter.PostedMetrics[0].Type).To(Equal(metricEvent))
+		Expect(metricAdapter.PostedMetrics[1].Type).To(Equal(logEvent))
 		Expect(logAdapter.PostedLogs).To(HaveLen(2))
-		Expect(logAdapter.PostedLogs[0].Payload.(*messages.MetricEvent).Type).To(Equal(metricEvent))
-		Expect(logAdapter.PostedLogs[1].Payload.(*messages.MetricEvent).Type).To(Equal(logEvent))
+		Expect(logAdapter.PostedLogs[0].Payload.(*messages.Metric).Type).To(Equal(metricEvent))
+		Expect(logAdapter.PostedLogs[1].Payload.(*messages.Metric).Type).To(Equal(logEvent))
 	})
 
 	It("can translate Metric statements to Logs", func() {
@@ -62,19 +62,20 @@ var _ = Describe("Router", func() {
 		labels := map[string]string{"foo": "bar"}
 		metric := &messages.Metric{
 			Name:      "valueMetric",
+			Labels:    labels,
 			Value:     float64(123),
 			EventTime: time.Now(),
 			Unit:      "f",
+			Type:      logEvent,
 		}
-		metricEvent := &messages.MetricEvent{Type: logEvent, Labels: labels, Metrics: []*messages.Metric{metric}}
 		router := NewRouter(nil, nil, logAdapter, []events.Envelope_EventType{logEvent})
-		router.PostMetricEvents([]*messages.MetricEvent{metricEvent})
+		router.PostMetrics([]*messages.Metric{metric})
 		Expect(logAdapter.PostedLogs).To(HaveLen(1))
 		log := logAdapter.PostedLogs[0]
 		Expect(log.Labels).To(Equal(labels))
-		Expect(log.Payload).To(BeAssignableToTypeOf(&messages.MetricEvent{}))
-		payload := log.Payload.(*messages.MetricEvent)
-		Expect(payload.Metrics).To(Equal([]*messages.Metric{metric}))
+		Expect(log.Payload).To(BeAssignableToTypeOf(&messages.Metric{}))
+		payload := log.Payload.(*messages.Metric)
+		Expect(payload).To(Equal(metric))
 		Expect(payload.Type).To(Equal(logEvent))
 		Expect(payload.Labels).To(Equal(labels))
 	})

--- a/src/stackdriver-nozzle/mocks/metric_adapter.go
+++ b/src/stackdriver-nozzle/mocks/metric_adapter.go
@@ -25,27 +25,27 @@ import (
 type MetricAdapter struct {
 	sync.Mutex
 
-	PostMetricEventsFn    func(metrics []*messages.MetricEvent) error
-	PostMetricEventsCount int
-	PostedMetricEvents    []*messages.MetricEvent
+	PostMetricsFn    func(metrics []*messages.Metric) error
+	PostMetricsCount int
+	PostedMetrics    []*messages.Metric
 }
 
-func (m *MetricAdapter) PostMetricEvents(events []*messages.MetricEvent) {
+func (m *MetricAdapter) PostMetrics(metrics []*messages.Metric) {
 	m.Lock()
 	defer m.Unlock()
 
-	m.PostMetricEventsCount += 1
+	m.PostMetricsCount += 1
 
-	if m.PostMetricEventsFn != nil {
-		m.PostMetricEventsFn(events)
+	if m.PostMetricsFn != nil {
+		m.PostMetricsFn(metrics)
 	}
 
-	m.PostedMetricEvents = append(m.PostedMetricEvents, events...)
+	m.PostedMetrics = append(m.PostedMetrics, metrics...)
 }
 
-func (m *MetricAdapter) GetPostedMetricEvents() []*messages.MetricEvent {
+func (m *MetricAdapter) GetPostedMetrics() []*messages.Metric {
 	m.Lock()
 	defer m.Unlock()
 
-	return m.PostedMetricEvents
+	return m.PostedMetrics
 }

--- a/src/stackdriver-nozzle/mocks/metrics_buffer.go
+++ b/src/stackdriver-nozzle/mocks/metrics_buffer.go
@@ -22,11 +22,9 @@ type MetricsBuffer struct {
 	PostedMetrics []messages.Metric
 }
 
-func (m *MetricsBuffer) PostMetricEvents(events []*messages.MetricEvent) {
-	for _, event := range events {
-		for _, metric := range event.Metrics {
-			m.PostedMetrics = append(m.PostedMetrics, *metric)
-		}
+func (m *MetricsBuffer) PostMetrics(metrics []*messages.Metric) {
+	for _, metric := range metrics {
+		m.PostedMetrics = append(m.PostedMetrics, *metric)
 	}
 }
 

--- a/src/stackdriver-nozzle/nozzle/metric_sink_test.go
+++ b/src/stackdriver-nozzle/nozzle/metric_sink_test.go
@@ -86,9 +86,11 @@ var _ = Describe("MetricSink", func() {
 		Expect(metrics).To(HaveLen(1))
 		Expect(metrics[0]).To(MatchAllFields(Fields{
 			"Name":      Equal("firehose/origin.valueMetricName"),
+			"Labels":    Equal(labels),
 			"Value":     Equal(123.456),
 			"EventTime": Ignore(),
 			"Unit":      Equal("{foo}"),
+			"Type":      Equal(eventType),
 		}))
 		Expect(metrics[0].EventTime.UnixNano()).To(Equal(timeStamp))
 
@@ -136,11 +138,11 @@ var _ = Describe("MetricSink", func() {
 		}
 
 		Expect(metrics).To(MatchAllElements(eventName, Elements{
-			"firehose/origin.diskBytesQuota":   MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(1073741824)), "EventTime": Ignore(), "Unit": Equal("")}),
-			"firehose/origin.cpuPercentage":    MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(0.061651273460637)), "EventTime": Ignore(), "Unit": Equal("")}),
-			"firehose/origin.diskBytes":        MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(164634624)), "EventTime": Ignore(), "Unit": Equal("")}),
-			"firehose/origin.memoryBytes":      MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(16601088)), "EventTime": Ignore(), "Unit": Equal("")}),
-			"firehose/origin.memoryBytesQuota": MatchAllFields(Fields{"Name": Ignore(), "Value": Equal(float64(33554432)), "EventTime": Ignore(), "Unit": Equal("")}),
+			"firehose/origin.diskBytesQuota":   MatchAllFields(Fields{"Name": Ignore(), "Labels": Equal(labels), "Type": Equal(metricType), "Value": Equal(float64(1073741824)), "EventTime": Ignore(), "Unit": Equal("")}),
+			"firehose/origin.cpuPercentage":    MatchAllFields(Fields{"Name": Ignore(), "Labels": Equal(labels), "Type": Equal(metricType), "Value": Equal(float64(0.061651273460637)), "EventTime": Ignore(), "Unit": Equal("")}),
+			"firehose/origin.diskBytes":        MatchAllFields(Fields{"Name": Ignore(), "Labels": Equal(labels), "Type": Equal(metricType), "Value": Equal(float64(164634624)), "EventTime": Ignore(), "Unit": Equal("")}),
+			"firehose/origin.memoryBytes":      MatchAllFields(Fields{"Name": Ignore(), "Labels": Equal(labels), "Type": Equal(metricType), "Value": Equal(float64(16601088)), "EventTime": Ignore(), "Unit": Equal("")}),
+			"firehose/origin.memoryBytesQuota": MatchAllFields(Fields{"Name": Ignore(), "Labels": Equal(labels), "Type": Equal(metricType), "Value": Equal(float64(33554432)), "EventTime": Ignore(), "Unit": Equal("")}),
 		}))
 	})
 
@@ -176,15 +178,19 @@ var _ = Describe("MetricSink", func() {
 		Expect(metrics).To(MatchAllElements(eventName, Elements{
 			"firehose/origin.counterName.delta": MatchAllFields(Fields{
 				"Name":      Ignore(),
+				"Labels":    Equal(labels),
 				"Value":     Equal(float64(654321)),
 				"EventTime": Ignore(),
 				"Unit":      Equal(""),
+				"Type":      Equal(eventType),
 			}),
 			"firehose/origin.counterName.total": MatchAllFields(Fields{
 				"Name":      Ignore(),
+				"Labels":    Equal(labels),
 				"Value":     Equal(float64(123456)),
 				"EventTime": Ignore(),
 				"Unit":      Equal(""),
+				"Type":      Equal(eventType),
 			}),
 		}))
 	})


### PR DESCRIPTION
`MetricEvent` seems like an artifact of Firehose data model (`Envelope` being separate from the metric itself) which is quite unusual and difficult to reason about. I would like to propose merging `Metric` and `MetricEvent` structs.

I've realized that `router.PostMetrics` also sends metric events to Stackdriver logging, and this changes the payload. Please let me know if you think it's a concern.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cloudfoundry-community/stackdriver-tools/156)
<!-- Reviewable:end -->
