### PR TITLE
Change "director" to "foundation" at Pivotal's request.

### DIFF
--- a/jobs/stackdriver-nozzle/spec
+++ b/jobs/stackdriver-nozzle/spec
@@ -64,6 +64,6 @@ properties:
     description: Prefix added to all metric names being sent to Stackdriver, e.g. 'custom/PREFIX/gorouter.total_requests'. May contain slashes.
     default: firehose
 
-  nozzle.bosh_director_name:
-    description: Name added as the 'director' label to all time series being sent to Stackdriver, useful for differentiating between multiple PCF instances in a project.
+  nozzle.bosh_foundation_name:
+    description: Name added as the 'foundation' label to all time series being sent to Stackdriver, useful for differentiating between multiple PCF instances in a project.
     default: cf

--- a/jobs/stackdriver-nozzle/templates/stackdriver-nozzle-ctl.erb
+++ b/jobs/stackdriver-nozzle/templates/stackdriver-nozzle-ctl.erb
@@ -35,7 +35,7 @@ case $1 in
     export METRICS_BUFFER_DURATION=<%= p('nozzle.metrics_buffer_duration', '30') %>
     export METRICS_BATCH_SIZE=<%= p('nozzle.metrics_batch_size', '200') %>
     export METRIC_PATH_PREFIX=<%= p('nozzle.metric_path_prefix', 'firehose') %>
-    export BOSH_DIRECTOR_NAME=<%= p('nozzle.bosh_director_name', 'cf') %>
+    export BOSH_FOUNDATION_NAME=<%= p('nozzle.bosh_foundation_name', 'cf') %>
     export LOGGING_BATCH_COUNT=<%= p('nozzle.logging_batch_count', '1000') %>
     export LOGGING_BATCH_DURATION=<%= p('nozzle.logging_batch_duration', '30') %>
 

--- a/src/stackdriver-nozzle/README.md
+++ b/src/stackdriver-nozzle/README.md
@@ -39,7 +39,7 @@ go get github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-nozzl
 
 #### Nozzle
 
-- `BOSH_DIRECTOR_NAME` - sets the value of the "director" label added to every
+- `BOSH_FOUNDATION_NAME` - sets the value of the "foundation" label added to every
   metric / log exported to Stackdriver; defaults to "cf". This is useful for
   differentiating between multiple cloud foundry / BOSH instances in the same
   GCP / Stackdriver project.

--- a/src/stackdriver-nozzle/app/builder.go
+++ b/src/stackdriver-nozzle/app/builder.go
@@ -70,7 +70,7 @@ func New(c *config.Config, logger lager.Logger) *App {
 	} else {
 		appInfoRepository = cloudfoundry.NullAppInfoRepository()
 	}
-	labelMaker := nozzle.NewLabelMaker(appInfoRepository, c.BoshDirectorName)
+	labelMaker := nozzle.NewLabelMaker(appInfoRepository, c.BoshFoundationName)
 
 	return &App{
 		logger:      logger,

--- a/src/stackdriver-nozzle/config/config.go
+++ b/src/stackdriver-nozzle/config/config.go
@@ -66,7 +66,7 @@ type Config struct {
 	MetricsBufferDuration int    `envconfig:"metrics_buffer_duration" default:"30"`
 	MetricsBatchSize      int    `envconfig:"metrics_batch_size" default:"200"`
 	MetricPathPrefix      string `envconfig:"metric_path_prefix" default:"firehose"`
-	BoshDirectorName      string `envconfig:"bosh_director_name" default:"cf"`
+	BoshFoundationName    string `envconfig:"bosh_foundation_name" default:"cf"`
 	ResolveAppMetadata    bool   `envconfig:"resolve_app_metadata"`
 	NozzleId              string `envconfig:"nozzle_id" default:"local-nozzle"`
 	NozzleName            string `envconfig:"nozzle_name" default:"local-nozzle"`

--- a/src/stackdriver-nozzle/nozzle/label_maker.go
+++ b/src/stackdriver-nozzle/nozzle/label_maker.go
@@ -32,16 +32,16 @@ type LabelMaker interface {
 	LogLabels(*events.Envelope) map[string]string
 }
 
-func NewLabelMaker(appInfoRepository cloudfoundry.AppInfoRepository, directorName string) LabelMaker {
+func NewLabelMaker(appInfoRepository cloudfoundry.AppInfoRepository, foundationName string) LabelMaker {
 	return &labelMaker{
 		appInfoRepository: appInfoRepository,
-		directorName:      directorName,
+		foundationName:    foundationName,
 	}
 }
 
 type labelMaker struct {
 	appInfoRepository cloudfoundry.AppInfoRepository
-	directorName      string
+	foundationName    string
 }
 
 type labelMap map[string]string
@@ -81,7 +81,7 @@ func (pm *pathMaker) String() string {
 func (lm *labelMaker) MetricLabels(envelope *events.Envelope) map[string]string {
 	labels := labelMap{}
 
-	labels.setIfNotEmpty("director", lm.directorName)
+	labels.setIfNotEmpty("foundation", lm.foundationName)
 	labels.setIfNotEmpty("job", envelope.GetJob())
 	labels.setIfNotEmpty("index", envelope.GetIndex())
 	labels.setIfNotEmpty("applicationPath", lm.getApplicationPath(envelope))

--- a/src/stackdriver-nozzle/nozzle/label_maker_test.go
+++ b/src/stackdriver-nozzle/nozzle/label_maker_test.go
@@ -28,7 +28,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-const director = "bosh-director"
+const foundation = "bosh-foundation"
 
 var _ = Describe("LabelMaker", func() {
 	var (
@@ -37,7 +37,7 @@ var _ = Describe("LabelMaker", func() {
 	)
 
 	BeforeEach(func() {
-		subject = nozzle.NewLabelMaker(cloudfoundry.NullAppInfoRepository(), director)
+		subject = nozzle.NewLabelMaker(cloudfoundry.NullAppInfoRepository(), foundation)
 	})
 
 	It("makes labels from envelopes", func() {
@@ -68,18 +68,18 @@ var _ = Describe("LabelMaker", func() {
 		logLabels := subject.LogLabels(envelope)
 
 		Expect(metricLabels).To(Equal(map[string]string{
-			"director": director,
-			"job":      job,
-			"index":    index,
-			"tags":     "bar=foo,foo=bar",
+			"foundation": foundation,
+			"job":        job,
+			"index":      index,
+			"tags":       "bar=foo,foo=bar",
 		}))
 		Expect(logLabels).To(Equal(map[string]string{
-			"director":  director,
-			"job":       job,
-			"index":     index,
-			"tags":      "bar=foo,foo=bar",
-			"origin":    origin,
-			"eventType": "HttpStartStop",
+			"foundation": foundation,
+			"job":        job,
+			"index":      index,
+			"tags":       "bar=foo,foo=bar",
+			"origin":     origin,
+			"eventType":  "HttpStartStop",
 		}))
 	})
 
@@ -107,10 +107,10 @@ var _ = Describe("LabelMaker", func() {
 		labels := subject.MetricLabels(envelope)
 
 		Expect(labels).To(Equal(map[string]string{
-			"director": director,
-			"job":      job,
-			"index":    index,
-			"tags":     "foo=bar",
+			"foundation": foundation,
+			"job":        job,
+			"index":      index,
+			"tags":       "foo=bar",
 		}))
 	})
 
@@ -131,7 +131,7 @@ var _ = Describe("LabelMaker", func() {
 				appInfoRepository = &mocks.AppInfoRepository{
 					AppInfoMap: map[string]cloudfoundry.AppInfo{},
 				}
-				subject = nozzle.NewLabelMaker(appInfoRepository, director)
+				subject = nozzle.NewLabelMaker(appInfoRepository, foundation)
 			})
 
 			Context("for a LogMessage", func() {

--- a/tile.yml.erb
+++ b/tile.yml.erb
@@ -6,7 +6,7 @@ end
 ---
 name: <%=ENV["TILE_NAME"] %>
 label: <%=ENV["TILE_LABEL"] %>
-description: Import your Cloud Foundry logs and metrics into Stackdriver Logging and Monitoring for diagnostics and alerting 
+description: Import your Cloud Foundry logs and metrics into Stackdriver Logging and Monitoring for diagnostics and alerting
 icon_file: gcp_logo.png
 packages:
 - name: stackdriver-tools
@@ -40,7 +40,7 @@ packages:
         metrics_buffer_duration: (( .properties.metrics_buffer_duration.value ))
         metrics_batch_size: (( .properties.metrics_batch_size.value ))
         metric_path_prefix: (( .properties.metric_path_prefix.value ))
-        bosh_director_name: (( .properties.bosh_director_name.value ))
+        bosh_foundation_name: (( .properties.bosh_foundation_name.value ))
         logging_batch_count: (( .properties.logging_batch_count.value ))
         logging_batch_duration: (( .properties.logging_batch_duration.value ))
         debug: (( .properties.debug.value ))
@@ -59,7 +59,7 @@ forms:
     default: HttpStartStop,LogMessage,Error
     label: Whitelist for Stackdriver Logging
     description: |
-      Comma separated list without spaces consisting of any or all of HttpStartStop,LogMessage,Error. 
+      Comma separated list without spaces consisting of any or all of HttpStartStop,LogMessage,Error.
       The following events are in beta can also be used: ValueMetric,CounterEvent,ContainerMetric
   - name: firehose_events_to_stackdriver_monitoring
     type: string
@@ -111,11 +111,11 @@ forms:
     default: firehose
     label: Metric Path Prefix
     description: Prefix added to all metric names being sent to Stackdriver, e.g. 'custom/PREFIX/gorouter.total_requests'. May contain slashes.
-  - name: bosh_director_name
+  - name: bosh_foundation_name
     type: string
     default: cf
-    label: Bosh Director Name
-    description: Name added as the 'director' label to all time series being sent to Stackdriver, useful for differentiating between multiple PCF instances in a project.
+    label: Bosh Foundation Name
+    description: Name added as the 'foundation' label to all time series being sent to Stackdriver, useful for differentiating between multiple PCF instances in a project.
   - name: debug
     type: boolean
     default: false


### PR DESCRIPTION
It turns out that "foundation" is their name for a PCF install and
the BOSH director is just one part of that, albeit an important one.