### PR TITLE
Deduplicate runtime metrics (fix #157)

### DIFF
--- a/src/stackdriver-nozzle/config/config.go
+++ b/src/stackdriver-nozzle/config/config.go
@@ -72,6 +72,8 @@ type Config struct {
 	NozzleName            string `envconfig:"nozzle_name" default:"local-nozzle"`
 	NozzleZone            string `envconfig:"nozzle_zone" default:"local-nozzle"`
 	DebugNozzle           bool   `envconfig:"debug_nozzle"`
+	// By default 'origin' label is prepended to metric name, however for runtime metrics (defined here) we add it as a metric label instead.
+	RuntimeMetricRegex string `envconfig:"runtime_metric_regex" default:"^(numCPUS|numGoRoutines|memoryStats\\..*)$"`
 }
 
 func (c *Config) validate() error {

--- a/src/stackdriver-nozzle/mocks/label_maker.go
+++ b/src/stackdriver-nozzle/mocks/label_maker.go
@@ -22,7 +22,7 @@ type LabelMaker struct {
 	Labels map[string]string
 }
 
-func (lm *LabelMaker) MetricLabels(*events.Envelope) map[string]string {
+func (lm *LabelMaker) MetricLabels(*events.Envelope, bool) map[string]string {
 	return lm.Labels
 }
 

--- a/src/stackdriver-nozzle/nozzle/label_maker_test.go
+++ b/src/stackdriver-nozzle/nozzle/label_maker_test.go
@@ -63,7 +63,7 @@ var _ = Describe("LabelMaker", func() {
 			Tags:       tags,
 		}
 
-		metricLabels := subject.MetricLabels(envelope)
+		metricLabels := subject.MetricLabels(envelope, false)
 		logLabels := subject.LogLabels(envelope)
 
 		Expect(metricLabels).To(Equal(map[string]string{
@@ -103,7 +103,7 @@ var _ = Describe("LabelMaker", func() {
 			Tags:       tags,
 		}
 
-		labels := subject.MetricLabels(envelope)
+		labels := subject.MetricLabels(envelope, false)
 
 		Expect(labels).To(Equal(map[string]string{
 			"foundation": foundation,
@@ -165,7 +165,7 @@ var _ = Describe("LabelMaker", func() {
 
 					appInfoRepository.AppInfoMap[appGuid] = app
 
-					labels := subject.MetricLabels(envelope)
+					labels := subject.MetricLabels(envelope, false)
 
 					Expect(labels).To(HaveKeyWithValue("applicationPath",
 						"/MyOrg/MySpace/MyApp"))
@@ -174,7 +174,7 @@ var _ = Describe("LabelMaker", func() {
 				})
 
 				It("doesn't add fields for an unresolved app", func() {
-					labels := subject.MetricLabels(envelope)
+					labels := subject.MetricLabels(envelope, false)
 
 					Expect(labels).NotTo(HaveKey("applicationPath"))
 				})
@@ -213,7 +213,7 @@ var _ = Describe("LabelMaker", func() {
 
 					appInfoRepository.AppInfoMap[appGuid] = app
 
-					labels := subject.MetricLabels(envelope)
+					labels := subject.MetricLabels(envelope, false)
 
 					Expect(labels).To(HaveKeyWithValue("applicationPath",
 						"/MyOrg/MySpace/MyApp"))
@@ -232,7 +232,7 @@ var _ = Describe("LabelMaker", func() {
 					appInfoRepository.AppInfoMap[appGuid] = app
 
 					envelope.HttpStartStop.InstanceIndex = nil
-					labels := subject.MetricLabels(envelope)
+					labels := subject.MetricLabels(envelope, false)
 
 					Expect(labels).To(HaveKeyWithValue("applicationPath",
 						"/MyOrg/MySpace/MyApp"))
@@ -240,7 +240,7 @@ var _ = Describe("LabelMaker", func() {
 				})
 
 				It("doesn't add fields for an unresolved app", func() {
-					labels := subject.MetricLabels(envelope)
+					labels := subject.MetricLabels(envelope, false)
 
 					Expect(labels).NotTo(HaveKey("applicationPath"))
 				})


### PR DESCRIPTION
I've chosen to call these "runtime metrics" based on [the piece that generates them](https://github.com/cloudfoundry/dropsonde/blob/master/runtime_stats/runtime_stats.go).
Please let me know if you can come up with a better term :)

The regular expression is part of the config to avoid hard-coding it as a string elsewhere. I don't really expect anyone to override this, which is why it's not wired through to the manifest or tile.

I considered a comma-separated list of metric names instead of a regular expression, but it will be pretty long. Happy to do that if you think the performance difference matters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cloudfoundry-community/stackdriver-tools/161)
<!-- Reviewable:end -->
