### PR TITLE
Send all events to both Nozzle sinks.

### DIFF
--- a/src/stackdriver-nozzle/nozzle/nozzle.go
+++ b/src/stackdriver-nozzle/nozzle/nozzle.go
@@ -156,11 +156,8 @@ func (n *nozzle) Stop() error {
 func (n *nozzle) handleEvent(envelope *events.Envelope) {
 	firehoseEventsReceived.Increment()
 	firehoseEventsTotal.Increment()
-	if isMetric(envelope) {
-		n.metricSink.Receive(envelope)
-	} else {
-		n.logSink.Receive(envelope)
-	}
+	n.metricSink.Receive(envelope)
+	n.logSink.Receive(envelope)
 }
 
 func (n *nozzle) handleFirehoseError(err error) {
@@ -183,14 +180,5 @@ func (n *nozzle) handleFirehoseError(err error) {
 		firehoseErrClosePolicyViolation.Increment()
 	default:
 		firehoseErrCloseUnknown.Increment()
-	}
-}
-
-func isMetric(envelope *events.Envelope) bool {
-	switch envelope.GetEventType() {
-	case events.Envelope_ValueMetric, events.Envelope_ContainerMetric, events.Envelope_CounterEvent:
-		return true
-	default:
-		return false
 	}
 }


### PR DESCRIPTION
The Nozzle should delegate event routing decisions to the filter sink,
instead of having a second, hard-coded set of events that are metrics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cloudfoundry-community/stackdriver-tools/163)
<!-- Reviewable:end -->
