### PR TITLE
Do not send log events to metric sink

### DIFF
--- a/src/stackdriver-nozzle/app/builder.go
+++ b/src/stackdriver-nozzle/app/builder.go
@@ -88,8 +88,7 @@ func (a *App) newConsumer(ctx context.Context) (nozzle.Nozzle, error) {
 		return nil, err
 	}
 	// Filter Firehose events to what the user selects
-	metricRouterEvents := append(logEvents, metricEvents...)
-	filteredMetricSink, err := nozzle.NewFilterSink(metricRouterEvents, metricSink)
+	filteredMetricSink, err := nozzle.NewFilterSink(metricEvents, metricSink)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
After #163 there is no hard-coded filtering based on event type, and `firehose_events_to_stackdriver_logging` and `firehose_events_to_stackdriver_monitoring` actually determine which events should be sent to which sink.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cloudfoundry-community/stackdriver-tools/169)
<!-- Reviewable:end -->
