### PR TITLE
Per-app HTTP metrics derived from HttpStartStop events.

### DIFF
--- a/jobs/stackdriver-nozzle/spec
+++ b/jobs/stackdriver-nozzle/spec
@@ -73,6 +73,10 @@ properties:
     description: Enable reporting counter events as cumulative Stackdriver metrics. This requires all CounterEvent messages for a given metric to be routed to the same nozzle process (which is the case if you run a single copy of the nozzle).
     default: false
 
+  nozzle.enable_app_http_metrics:
+    description: Enable generation of per-app HTTP metrics from HttpStartStop events.
+    default: false
+
   nozzle.event_filters.blacklist:
     description: |
       Should contain an array of maps with three keys 'sink' (valid values:

--- a/jobs/stackdriver-nozzle/templates/stackdriver-nozzle-ctl.erb
+++ b/jobs/stackdriver-nozzle/templates/stackdriver-nozzle-ctl.erb
@@ -39,6 +39,7 @@ case $1 in
     export LOGGING_BATCH_COUNT=<%= p('nozzle.logging_batch_count', '1000') %>
     export LOGGING_BATCH_DURATION=<%= p('nozzle.logging_batch_duration', '30') %>
     export ENABLE_CUMULATIVE_COUNTERS=<%= p('nozzle.enable_cumulative_counters', 'false') %>
+    export ENABLE_APP_HTTP_METRICS=<%= p('nozzle.enable_app_http_metrics', 'false') %>
 
     <% if_p('gcp.project_id') do |prop| %>
     export GCP_PROJECT_ID=<%= prop %>

--- a/src/stackdriver-nozzle/config/config.go
+++ b/src/stackdriver-nozzle/config/config.go
@@ -90,6 +90,9 @@ type Config struct {
 	// requires deterministic routing of CounterEvents to nozzles (i.e. CounterEvent messages for a particular metric MUST
 	// always be routed to the same nozzle process); the easiest way to achieve that is to run a single copy of the nozzle.
 	EnableCumulativeCounters bool `envconfig:"enable_cumulative_counters"`
+	// If enabled, the Nozzle will derive per-application HTTP metrics from
+	// HttpStartStop events and export them as counters to Stackdriver.
+	EnableAppHttpMetrics bool `envconfig:"enable_app_http_metrics"`
 	// Expire internal counter state if a given counter has not been seen for this many seconds.
 	CounterTrackerTTL int `envconfig:"counter_tracker_ttl" default:"130"`
 

--- a/src/stackdriver-nozzle/messages/metric.go
+++ b/src/stackdriver-nozzle/messages/metric.go
@@ -109,15 +109,26 @@ func (m *Metric) Hash() string {
 	var b bytes.Buffer
 
 	b.Write([]byte(m.Name))
+	if len(m.Labels) > 0 {
+		b.WriteByte(',')
+		b.WriteString(Flatten(m.Labels))
+	}
+	return b.String()
+}
 
-	// Extract label keys to a slice and sort it
-	keys := make([]string, 0, len(m.Labels))
-	for k := range m.Labels {
+// Flatten serializes a set of label keys and values.
+func Flatten(labels map[string]string) string {
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
-	for _, k := range keys {
-		b.Write([]byte(fmt.Sprintf(",%s='%s'", k, m.Labels[k])))
+	buf := &bytes.Buffer{}
+	for i, k := range keys {
+		buf.WriteString(fmt.Sprintf("%q=%q", k, labels[k]))
+		if i+1 < len(keys) {
+			buf.WriteByte(',')
+		}
 	}
-	return b.String()
+	return buf.String()
 }

--- a/src/stackdriver-nozzle/nozzle/httpstartstop_sink.go
+++ b/src/stackdriver-nozzle/nozzle/httpstartstop_sink.go
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nozzle
+
+import (
+	"fmt"
+
+	"github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-nozzle/telemetry"
+	"github.com/cloudfoundry/lager"
+	"github.com/cloudfoundry/sonde-go/events"
+)
+
+const httpPrefix telemetry.MetricPrefix = "app-http"
+
+var (
+	requestCount *telemetry.CounterMap
+	responseCode *telemetry.CounterMap
+
+	defaultLabels = []string{"job", "index", "applicationPath", "instanceIndex"}
+)
+
+func init() {
+	requestCount = telemetry.NewCounterMap(httpPrefix, "request_count",
+		defaultLabels...)
+	responseCode = telemetry.NewCounterMap(httpPrefix, "response_code",
+		append(defaultLabels, "code")...)
+}
+
+type httpSink struct {
+	logger     lager.Logger
+	labelMaker LabelMaker
+}
+
+// NewHttpSink returns a Sink that can receive sonde HttpStartStop events
+// and generate per-application HTTP metrics from them.
+func NewHttpSink(logger lager.Logger, labelMaker LabelMaker) Sink {
+	return &httpSink{
+		logger:     logger,
+		labelMaker: labelMaker,
+	}
+}
+
+func (sink *httpSink) Receive(envelope *events.Envelope) {
+	if envelope.GetEventType() != events.Envelope_HttpStartStop {
+		return
+	}
+
+	labels := sink.labelMaker.MetricLabels(envelope, false)
+	if labels["applicationPath"] == "" {
+		// We're only interested in HTTP traffic passing through the gorouters
+		// to known applications.
+		return
+	}
+	labelValues := defaultLabelValues(labels)
+
+	if rcc, err := requestCount.Counter(labelValues...); err == nil {
+		rcc.Increment()
+	} else {
+		sink.logger.Error("httpSink.Receive", fmt.Errorf("incrementing requestCount: %v", err))
+	}
+	code := fmt.Sprintf("%d", envelope.GetHttpStartStop().GetStatusCode())
+	if rcc, err := responseCode.Counter(append(labelValues, code)...); err == nil {
+		rcc.Increment()
+	} else {
+		sink.logger.Error("httpSink.Receive", fmt.Errorf("incrementing responseCode: %v", err))
+	}
+}
+
+func defaultLabelValues(labels map[string]string) []string {
+	labelValues := make([]string, len(defaultLabels))
+	for i, key := range defaultLabels {
+		labelValues[i] = labels[key]
+	}
+	return labelValues
+}

--- a/src/stackdriver-nozzle/nozzle/httpstartstop_sink_test.go
+++ b/src/stackdriver-nozzle/nozzle/httpstartstop_sink_test.go
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nozzle
+
+import (
+	"strconv"
+
+	"github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-nozzle/cloudfoundry"
+	"github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-nozzle/messages"
+	"github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-nozzle/mocks"
+	"github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-nozzle/telemetry"
+	"github.com/cloudfoundry/sonde-go/events"
+	"github.com/golang/protobuf/proto"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type testApp struct {
+	name      string
+	low, high uint64
+}
+
+func (ta testApp) GUID() string {
+	return formatUUID(ta.UUID())
+}
+
+func (ta testApp) UUID() *events.UUID {
+	return &events.UUID{Low: &ta.low, High: &ta.high}
+}
+
+func (ta testApp) Index() string {
+	return formatUUID(&events.UUID{Low: &ta.high, High: &ta.low})
+}
+
+func (ta testApp) AppInfo() cloudfoundry.AppInfo {
+	return cloudfoundry.AppInfo{
+		AppName:   ta.name,
+		SpaceName: "Space",
+		OrgName:   "Org",
+	}
+}
+
+func (ta testApp) Events(count int, code, instanceIndex int32) []*events.Envelope {
+	ret := make([]*events.Envelope, count)
+	for i := 0; i < count; i++ {
+		ret[i] = &events.Envelope{
+			Origin:    proto.String("origin"),
+			EventType: events.Envelope_HttpStartStop.Enum(),
+			Job:       proto.String("router"),
+			Index:     proto.String(ta.Index()),
+			HttpStartStop: &events.HttpStartStop{
+				StatusCode:    &code,
+				InstanceIndex: &instanceIndex,
+				ApplicationId: ta.UUID(),
+			},
+		}
+	}
+	return ret
+}
+
+func (ta testApp) RequestCount(instanceIndex int) int {
+	key := messages.Flatten(map[string]string{
+		"job":             "router",
+		"index":           ta.Index(),
+		"applicationPath": makePath(ta.AppInfo()),
+		"instanceIndex":   strconv.Itoa(instanceIndex),
+	})
+	if ctr, ok := requestCount.Get(key).(*telemetry.Counter); ok {
+		return int(ctr.Value())
+	}
+	// Zero is a perfectly valid counter value, -1 not so much.
+	// Returning a separate error here is inconvenient.
+	return -1
+}
+
+func (ta testApp) ResponseCode(code, instanceIndex int) int {
+	key := messages.Flatten(map[string]string{
+		"job":             "router",
+		"index":           ta.Index(),
+		"applicationPath": makePath(ta.AppInfo()),
+		"instanceIndex":   strconv.Itoa(instanceIndex),
+		"code":            strconv.Itoa(code),
+	})
+	if ctr, ok := responseCode.Get(key).(*telemetry.Counter); ok {
+		return int(ctr.Value())
+	}
+	// Zero is a perfectly valid counter value, -1 not so much.
+	// Returning a separate error here is inconvenient.
+	return -1
+}
+
+var testApps = []testApp{
+	{"AppOne", 0x2234878713489723, 0x9df2ba7314302765},
+	{"AppTwo", 0x14338a4961390dea, 0x657381f23cc11739},
+	{"AppTri", 0xf3874ab3b321bb95, 0xa285f76e81964556},
+}
+
+var _ = Describe("HttpSink", func() {
+	var (
+		subject    Sink
+		labelMaker LabelMaker
+		foundation = "cf"
+		air        = &mocks.AppInfoRepository{AppInfoMap: map[string]cloudfoundry.AppInfo{}}
+	)
+
+	BeforeEach(func() {
+		for _, app := range testApps {
+			air.AppInfoMap[app.GUID()] = app.AppInfo()
+		}
+		labelMaker = NewLabelMaker(air, foundation)
+		subject = NewHttpSink(&mocks.MockLogger{}, labelMaker)
+	})
+
+	It("increments counters for reqeusts", func() {
+		receive := func(es []*events.Envelope) {
+			for _, e := range es {
+				subject.Receive(e)
+			}
+		}
+		// AppOne has 2 instances.
+		// The first serves 20 "200 OK" responses.
+		receive(testApps[0].Events(20, 200, 0))
+		// The second serves 18 "200 OK" and 2 "500 ISE" responses.
+		receive(testApps[0].Events(18, 200, 1))
+		receive(testApps[0].Events(2, 500, 1))
+
+		// AppTwo has one instance.
+		// It serves 15 "200 OK", 3 "401 Forbidden" and 7 "404 Not Found" responses.
+		receive(testApps[1].Events(15, 200, 0))
+		receive(testApps[1].Events(3, 401, 0))
+		receive(testApps[1].Events(7, 404, 0))
+
+		// AppTri has one instance.
+		// It serves 8 302 redirects.
+		receive(testApps[2].Events(8, 302, 0))
+
+		Expect(testApps[0].RequestCount(0)).To(Equal(20))
+		Expect(testApps[0].ResponseCode(200, 0)).To(Equal(20))
+		Expect(testApps[0].ResponseCode(500, 0)).To(Equal(-1))
+
+		Expect(testApps[0].RequestCount(1)).To(Equal(20))
+		Expect(testApps[0].ResponseCode(200, 1)).To(Equal(18))
+		Expect(testApps[0].ResponseCode(500, 1)).To(Equal(2))
+
+		Expect(testApps[0].RequestCount(2)).To(Equal(-1))
+		Expect(testApps[0].ResponseCode(200, 2)).To(Equal(-1))
+
+		Expect(testApps[1].RequestCount(0)).To(Equal(25))
+		Expect(testApps[1].ResponseCode(200, 0)).To(Equal(15))
+		Expect(testApps[1].ResponseCode(401, 0)).To(Equal(3))
+		Expect(testApps[1].ResponseCode(404, 0)).To(Equal(7))
+
+		Expect(testApps[2].RequestCount(0)).To(Equal(8))
+		Expect(testApps[2].ResponseCode(302, 0)).To(Equal(8))
+	})
+})

--- a/src/stackdriver-nozzle/nozzle/label_maker.go
+++ b/src/stackdriver-nozzle/nozzle/label_maker.go
@@ -121,6 +121,10 @@ func (lm *labelMaker) getApplicationPath(envelope *events.Envelope) string {
 		return ""
 	}
 
+	return makePath(app)
+}
+
+func makePath(app cloudfoundry.AppInfo) string {
 	path := pathMaker{}
 	path.addElement("org", app.OrgName)
 	path.addElement("space", app.SpaceName)

--- a/src/stackdriver-nozzle/nozzle/nozzle.go
+++ b/src/stackdriver-nozzle/nozzle/nozzle.go
@@ -53,17 +53,11 @@ var (
 func init() {
 	firehoseErrs = telemetry.NewCounterMap(telemetry.Nozzle, "firehose.errors", "error_type")
 
-	firehoseErrEmpty = &telemetry.Counter{}
-	firehoseErrUnknown = &telemetry.Counter{}
-	firehoseErrCloseNormal = &telemetry.Counter{}
-	firehoseErrClosePolicyViolation = &telemetry.Counter{}
-	firehoseErrCloseUnknown = &telemetry.Counter{}
-
-	firehoseErrs.Set("empty", firehoseErrEmpty)
-	firehoseErrs.Set("unknown", firehoseErrUnknown)
-	firehoseErrs.Set("close_normal_closure", firehoseErrCloseNormal)
-	firehoseErrs.Set("close_policy_violation", firehoseErrClosePolicyViolation)
-	firehoseErrs.Set("close_unknown", firehoseErrCloseUnknown)
+	firehoseErrEmpty = firehoseErrs.MustCounter("empty")
+	firehoseErrUnknown = firehoseErrs.MustCounter("unknown")
+	firehoseErrCloseNormal = firehoseErrs.MustCounter("close_normal_closure")
+	firehoseErrClosePolicyViolation = firehoseErrs.MustCounter("close_policy_violation")
+	firehoseErrCloseUnknown = firehoseErrs.MustCounter("close_unknown")
 
 	firehoseEventsTotal = telemetry.NewCounter(telemetry.Nozzle, "firehose_events.total")
 	firehoseEventsDropped = telemetry.NewCounter(telemetry.Nozzle, "firehose_events.dropped")

--- a/src/stackdriver-nozzle/stackdriver/metric_client.go
+++ b/src/stackdriver-nozzle/stackdriver/metric_client.go
@@ -44,11 +44,8 @@ func init() {
 	timeSeriesReqs = telemetry.NewCounter(telemetry.Nozzle, "metrics.timeseries.requests")
 	timeSeriesErrs = telemetry.NewCounterMap(telemetry.Nozzle, "metrics.timeseries.errors", "error_type")
 
-	timeSeriesErrOutOfOrder = &telemetry.Counter{}
-	timeSeriesErrUnknown = &telemetry.Counter{}
-
-	timeSeriesErrs.Set("out_of_order", timeSeriesErrOutOfOrder)
-	timeSeriesErrs.Set("unknown", timeSeriesErrUnknown)
+	timeSeriesErrOutOfOrder = timeSeriesErrs.MustCounter("out_of_order")
+	timeSeriesErrUnknown = timeSeriesErrs.MustCounter("unknown")
 
 	descriptorReqs = telemetry.NewCounter(telemetry.Nozzle, "metrics.descriptor.requests")
 	descriptorErrs = telemetry.NewCounter(telemetry.Nozzle, "metrics.descriptor.errors")

--- a/src/stackdriver-nozzle/telemetry/counters.go
+++ b/src/stackdriver-nozzle/telemetry/counters.go
@@ -18,13 +18,23 @@ package telemetry
 
 import (
 	"expvar"
+	"fmt"
 	"sync"
+
+	"github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-nozzle/messages"
 )
 
+// A Counter is a monotonically-increasing integer expvar associated with a
+// set of labels expressed as a key-value string map.
+//
+// Note that exporting custom labels for Counters to Stackdriver is only
+// implemented for counters that are part of a CounterMap.
 type Counter struct {
 	expvar.Int
+	Labels map[string]string
 }
 
+// Increment adds one to the counter's expvar value.
 func (c *Counter) Increment() {
 	c.Add(1)
 }
@@ -36,13 +46,52 @@ func (c *Counter) IntValue() int {
 	return int(c.Value())
 }
 
+// A CounterMap is used to export a set of related Counters which have the
+// same label keys.
 type CounterMap struct {
 	expvar.Map
-	category string
+	// While Map operations are synchronized, there is no CompareAndSwap
+	// primitive so we need a mutex to ensure there's no races between
+	// the Get and Set calls in Counter.
+	mu        sync.Mutex
+	LabelKeys []string
 }
 
-func (cm *CounterMap) Category() string {
-	return cm.category
+// Counter retrieves or creates a Counter with a given set of label values.
+func (cm *CounterMap) Counter(labelValues ...string) (*Counter, error) {
+	if len(labelValues) != len(cm.LabelKeys) {
+		return nil, fmt.Errorf("want %d label values for map, got %d",
+			len(cm.LabelKeys), len(labelValues))
+	}
+	v := &Counter{Labels: map[string]string{}}
+	for i, k := range cm.LabelKeys {
+		v.Labels[k] = labelValues[i]
+	}
+	key := messages.Flatten(v.Labels)
+
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	existing := cm.Get(key)
+	if existing == nil {
+		cm.Set(key, v)
+		return v, nil
+	}
+	if v, ok := existing.(*Counter); ok {
+		return v, nil
+	}
+	// Shouldn't reach here, it implies a non-Counter in the map.
+	return nil, fmt.Errorf("found non-Counter %#v in map", existing)
+}
+
+// MustCounter is a version of Counter that panics on error, for use
+// in init functions.
+func (cm *CounterMap) MustCounter(labelValues ...string) *Counter {
+	ctr, err := cm.Counter(labelValues...)
+	if err == nil {
+		return ctr
+	}
+	panic(err)
 }
 
 // The metricSet contains a map of metric prefixes and enables
@@ -75,10 +124,8 @@ func NewCounter(mp MetricPrefix, name string) *Counter {
 }
 
 // NewCounterMap creates and exports a new CounterMap for the MetricPrefix.
-func NewCounterMap(mp MetricPrefix, name, category string) *CounterMap {
-	v := new(CounterMap)
-	v.category = category
-
+func NewCounterMap(mp MetricPrefix, name string, labelKeys ...string) *CounterMap {
+	v := &CounterMap{LabelKeys: labelKeys}
 	publish(mp, name, v)
 	return v
 }

--- a/src/stackdriver-nozzle/telemetry/log_sink.go
+++ b/src/stackdriver-nozzle/telemetry/log_sink.go
@@ -55,7 +55,10 @@ func (ls *logSink) Report(values []*expvar.KeyValue) {
 		case *CounterMap:
 			data.Do(func(mapVal expvar.KeyValue) {
 				if counterVal, ok := mapVal.Value.(*Counter); ok {
-					record(fmt.Sprintf("%s.%s", val.Key, mapVal.Key), counterVal)
+					// TODO(fluffle): dumping high-cardinality maps into logs
+					// is pretty horrible, but this data is really helpful
+					// for debugging. Find a reasonable solution.
+					record(fmt.Sprintf("%s{%s}", val.Key, mapVal.Key), counterVal)
 				}
 			})
 		}


### PR DESCRIPTION
This will create Stackdriver metrics to track the request rates and response codes of individual PCF apps from the gorouter's HttpStartStop events. It allows the creation of simple SLIs based on e.g. the ratio of 500s.

I intend to use this as a proof-of-concept for per-application SLOs. It's not clear that this functionality *should* be in the nozzle, though if we want proper counters and latency distributions then it kinda has to be. I would appreciate code reviews anyway if you're not too busy :-)

Please don't merge this until we're sure the nozzle is the right place for this code, instead of e.g. having the gorouter track and emit these metrics.

/cc @johnsonj @knyar

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cloudfoundry-community/stackdriver-tools/175)
<!-- Reviewable:end -->
