### PR TITLE
event_filters.json: don't read property if it's not set

### DIFF
--- a/jobs/stackdriver-nozzle/templates/event_filters.json.erb
+++ b/jobs/stackdriver-nozzle/templates/event_filters.json.erb
@@ -1,7 +1,11 @@
 <%
-  require 'json'
-  config = {}
-  config["blacklist"] = p('nozzle.event_filters.blacklist') if p('nozzle.event_filters.blacklist')
-  config["whitelist"] = p('nozzle.event_filters.whitelist') if p('nozzle.event_filters.whitelist')
+require 'json'
+config = {}
+
+%w[blacklist whitelist].each do |prop|
+  if_p("nozzle.event_filters.#{prop}") do |val|
+    config[prop] = val
+  end
+end
 %>
 <%=config.to_json %>


### PR DESCRIPTION
Use if_p instead of the misguided (by my CR comment) if p("..")

fixes #181

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cloudfoundry-community/stackdriver-tools/182)
<!-- Reviewable:end -->
