### PR TITLE
Instrument telemetry path for SD metrics.

### DIFF
--- a/src/stackdriver-nozzle/stackdriver/metric_adapter_test.go
+++ b/src/stackdriver-nozzle/stackdriver/metric_adapter_test.go
@@ -47,9 +47,6 @@ var _ = Describe("MetricAdapter", func() {
 	BeforeEach(func() {
 		firehoseEventsCount.Set(0)
 		timeSeriesCount.Set(0)
-		timeSeriesReqs.Set(0)
-		timeSeriesErrOutOfOrder.Set(0)
-		timeSeriesErrUnknown.Set(0)
 
 		client = &mocks.MockClient{}
 		logger = &mocks.MockLogger{}
@@ -259,33 +256,9 @@ var _ = Describe("MetricAdapter", func() {
 		subject.PostMetrics(metrics)
 		Expect(firehoseEventsCount.IntValue()).To(Equal(3))
 		Expect(timeSeriesCount.IntValue()).To(Equal(3))
-		Expect(timeSeriesReqs.IntValue()).To(Equal(1))
 
 		subject.PostMetrics(metrics)
 		Expect(firehoseEventsCount.IntValue()).To(Equal(6))
 		Expect(timeSeriesCount.IntValue()).To(Equal(6))
-		Expect(timeSeriesReqs.IntValue()).To(Equal(2))
-	})
-
-	It("measures out of order errors", func() {
-		metrics := []*messages.Metric{{}}
-		client.PostFn = func(req *monitoringpb.CreateTimeSeriesRequest) error {
-			return errors.New("GRPC Stuff. Points must be written in order. Other stuff")
-		}
-
-		subject.PostMetrics(metrics)
-		Expect(timeSeriesErrOutOfOrder.IntValue()).To(Equal(1))
-		Expect(timeSeriesErrUnknown.IntValue()).To(Equal(0))
-	})
-
-	It("measures unknown errors", func() {
-		metrics := []*messages.Metric{{}}
-
-		client.PostFn = func(req *monitoringpb.CreateTimeSeriesRequest) error {
-			return errors.New("tragedy strikes")
-		}
-		subject.PostMetrics(metrics)
-		Expect(timeSeriesErrOutOfOrder.IntValue()).To(Equal(0))
-		Expect(timeSeriesErrUnknown.IntValue()).To(Equal(1))
 	})
 })

--- a/src/stackdriver-nozzle/stackdriver/telemetry_sink.go
+++ b/src/stackdriver-nozzle/stackdriver/telemetry_sink.go
@@ -125,9 +125,7 @@ func (ts *telemetrySink) Init(registeredSeries []*expvar.KeyValue) {
 				Description: "stackdriver-nozzle created custom metric.",
 			},
 		}
-		err := ts.client.CreateMetricDescriptor(req)
-
-		if err != nil {
+		if err := ts.client.CreateMetricDescriptor(req); err != nil {
 			ts.logger.Error("telemetrySink.CreateMetricDescriptor", err, lager.Data{"req": req})
 		}
 	}
@@ -165,13 +163,17 @@ func (ts *telemetrySink) Report(report []*expvar.KeyValue) {
 		req.TimeSeries = append(req.TimeSeries, ts.timeSeries(ts.metricDescriptorType(data.Key), interval, data)...)
 
 		if len(req.TimeSeries) == maxTimeSeries {
-			ts.client.Post(req)
+			if err := ts.client.Post(req); err != nil {
+				ts.logger.Error("telemetrySink.Report", err, lager.Data{"req": req})
+			}
 			req = ts.newRequest()
 		}
 	}
 
 	if len(req.TimeSeries) != 0 {
-		ts.client.Post(req)
+		if err := ts.client.Post(req); err != nil {
+			ts.logger.Error("telemetrySink.Report", err, lager.Data{"req": req})
+		}
 	}
 }
 


### PR DESCRIPTION
- Increment counters in metric client instead of metric adapter.
- Log SD errors returned to telemetry sink.

This is what prompted @knyar's PR #180. I have taken the lazy way out with tests: I just deleted the ones testing metric increments instead of trying to figure out a neat way of mocking/faking the Stackdriver client. If you'd prefer that I reinstate them, I can probably do that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cloudfoundry-community/stackdriver-tools/183)
<!-- Reviewable:end -->
