### PR TITLE
Use bosh2 in CI, documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ To use any of the jobs in this BOSH release, first upload it to your BOSH
 director:
 
 ```
-bosh upload-release https://storage.googleapis.com/bosh-gcp/beta/stackdriver-tools/latest.tgz
+bosh2 upload-release https://storage.googleapis.com/bosh-gcp/beta/stackdriver-tools/latest.tgz
 ```
 
 The [stackdriver-tools.yml][tools-yaml] sample [BOSH 2.0 manifest][bosh20] illustrates how to

--- a/README.md
+++ b/README.md
@@ -80,19 +80,36 @@ To use any of the jobs in this BOSH release, first upload it to your BOSH
 director:
 
 ```
-bosh upload release https://storage.googleapis.com/bosh-gcp/beta/stackdriver-tools/latest.tgz
+bosh upload-release https://storage.googleapis.com/bosh-gcp/beta/stackdriver-tools/latest.tgz
 ```
 
-The [stackdriver-tools.yml][tools-yaml] sample deployment manifest illustrates how to
+The [stackdriver-tools.yml][tools-yaml] sample [BOSH 2.0 manifest][bosh20] illustrates how to
 use all 3 jobs in this release (nozzle, host logging, and host monitoring). You
-can deploy the sample with:
+can deploy the sample with the following commands:
 
 [tools-yaml]: manifests/stackdriver-tools.yml
-
+[bosh20]: https://bosh.io/docs/manifest-v2.html
 
 ```
-bosh deployment manifests/stackdriver-tools.yml 
-bosh -n deploy
+bosh2 upload-stemcell https://bosh.io/d/stemcells/bosh-google-kvm-ubuntu-trusty-go_agent
+
+bosh2 update-cloud-config -n manifests/cloud-config-gcp.yml \
+          -v zone=... \
+          -v network=... \
+          -v subnetwork=... \
+          -v "tags=['stackdriver-nozzle']" \
+          -v internal_cidr=... \
+          -v internal_gw=... \
+          -v "reserved=[10....-10....]"
+
+bosh2 deploy manifests/stackdriver-tools.yml \
+            -d stackdriver-nozzle \
+            --var=firehose_endpoint=https://.. \
+            --var=firehose_username=stackdriver_nozzle \
+            --var=firehose_password=... \
+            --var=skip_ssl=false \
+            --var=gcp_project_id=... \
+            --var-file=gcp_service_account_json=path/to/service_account.json \
 ```
 
 This will create a self-contained deployment that sends Cloud Foundry firehose

--- a/ci/pipeline-develop.yml
+++ b/ci/pipeline-develop.yml
@@ -79,6 +79,7 @@ jobs:
           bosh_director_address: {{bosh_director_address}}
           bosh_user: {{bosh_user}}
           bosh_password: {{bosh_password}}
+          bosh_ca_cert: {{bosh_ca_cert}}
           google_region: {{google_region}}
           google_zone: {{google_zone}}
           network: {{network}}
@@ -121,8 +122,8 @@ resources:
   - name: stackdriver-tools-in
     type: git
     source:
-      uri: https://github.com/cloudfoundry-community/stackdriver-tools.git
-      branch: develop
+      uri: {{source_uri}}
+      branch: {{source_branch}}
       ignore_paths:
         - .final_builds/**/*.yml
         - releases/**/*.yml

--- a/ci/tasks/build-candidate.sh
+++ b/ci/tasks/build-candidate.sh
@@ -20,7 +20,7 @@ pushd stackdriver-tools
 
   # Force create because we just created the file `src/stackdriver-nozzle/release`
   echo "Creating ${release_name} BOSH Release..."
-  bosh2 create-release --name=${release_name} --version=${semver} --tarball=${image_path} --force
+  bosh2 create-release --name=${release_name} --version=${semver} --tarball=${image_path} --force --sha2
 popd
 
 echo -n $(sha256sum $image_path | awk '{print $1}') > $image_path.sha256

--- a/ci/tasks/deploy-candidate.sh
+++ b/ci/tasks/deploy-candidate.sh
@@ -37,7 +37,7 @@ ssh -4 -D 5000 -fNC bosh@${ssh_bastion_address} -i /tmp/${ssh_user}.key -o Stric
 export BOSH_ALL_PROXY=socks5://localhost:5000
 
 echo "Using BOSH CLI version..."
-bosh2 version
+bosh2 --version
 export BOSH_CLIENT=${bosh_user}
 export BOSH_CLIENT_SECRET=${bosh_password}
 export BOSH_ENVIRONMENT=https://${bosh_director_address}:25555

--- a/ci/tasks/deploy-candidate.sh
+++ b/ci/tasks/deploy-candidate.sh
@@ -32,10 +32,6 @@ echo "Configuring SSH"
 echo -e "${ssh_key}" > /tmp/${ssh_user}.key
 chmod 700 /tmp/${ssh_user}.key
 
-echo "Configuring credentials"
-echo -e "${cf_service_account_json}" > /tmp/service_account.json
-chmod 700 /tmp/service_account.json
-
 echo "Connecting to SSH bastion..."
 ssh -4 -D 5000 -fNC bosh@${ssh_bastion_address} -i /tmp/${ssh_user}.key -o StrictHostKeyChecking=no
 export BOSH_ALL_PROXY=socks5://localhost:5000
@@ -75,7 +71,7 @@ bosh2 deploy -n manifests/stackdriver-tools.yml \
             --var=firehose_password=${firehose_password} \
             --var=skip_ssl=true \
             --var=gcp_project_id=${cf_project_id} \
-            --var-file=gcp_service_account_json=/tmp/service_account.json
+            --var=gcp_service_account_json=${cf_service_account_json}
 
 popd
 

--- a/ci/tasks/deploy-candidate.sh
+++ b/ci/tasks/deploy-candidate.sh
@@ -54,6 +54,7 @@ bosh2 env
 echo "Uploading nozzle release..."
 bosh2 upload-release stackdriver-tools-artifacts/*.tgz
 
+pushd stackdriver-tools
 echo "Updating cloud config"
 bosh2 update-cloud-config -n manifests/cloud-config-gcp.yml \
           -v zone=${google_zone} \
@@ -65,6 +66,8 @@ bosh2 update-cloud-config -n manifests/cloud-config-gcp.yml \
           -v "reserved=[10.0.0.1-10.0.0.10]"
 
 bosh2 cloud-config
+
+echo "Deploying nozzle release"
 bosh2 deploy -n manifests/stackdriver-tools.yml \
             -d stackdriver-nozzle \
             --var=firehose_endpoint=${cf_api_url} \
@@ -73,6 +76,8 @@ bosh2 deploy -n manifests/stackdriver-tools.yml \
             --var=skip_ssl=true \
             --var=gcp_project_id=${cf_project_id} \
             --var-file=gcp_service_account_json=/tmp/service_account.json
+
+popd
 
 # Move release and its SHA256
 mv stackdriver-tools-artifacts/*.tgz candidate/latest.tgz

--- a/ci/tasks/deploy-candidate.sh
+++ b/ci/tasks/deploy-candidate.sh
@@ -32,6 +32,10 @@ echo "Configuring SSH"
 echo -e "${ssh_key}" > /tmp/${ssh_user}.key
 chmod 700 /tmp/${ssh_user}.key
 
+echo "Configuring credentials"
+echo -e "${cf_service_account_json}" > /tmp/service_account.json
+chmod 700 /tmp/service_account.json
+
 echo "Connecting to SSH bastion..."
 ssh -4 -D 5000 -fNC bosh@${ssh_bastion_address} -i /tmp/${ssh_user}.key -o StrictHostKeyChecking=no
 export BOSH_ALL_PROXY=socks5://localhost:5000
@@ -50,107 +54,25 @@ bosh2 env
 echo "Uploading nozzle release..."
 bosh2 upload-release stackdriver-tools-artifacts/*.tgz
 
-nozzle_manifest_name=stackdriver-nozzle.yml
-nozzle_deployment_name=stackdriver-nozzle-ci
-cat > ${nozzle_manifest_name} <<EOF
----
+echo "Updating cloud config"
+bosh2 update-cloud-config -n manifests/cloud-config-gcp.yml \
+          -v zone=${google_zone} \
+          -v network=${network} \
+          -v subnetwork=${private_subnetwork} \
+          -v "tags=['stackdriver-nozzle']" \
+          -v internal_cidr=10.0.0.0/16 \
+          -v internal_gw=10.0.0.1 \
+          -v "reserved=[10.0.0.1-10.0.0.10]"
 
-name: ${nozzle_deployment_name}
-
-releases:
-- name: stackdriver-tools
-  version: ${semver}
-
-jobs:
-- name: stackdriver-nozzle
-  instances: 1
-  networks:
-    - name: private
-  resource_pool: common
-  templates:
-    - name: stackdriver-nozzle
-      release: stackdriver-tools
-    - name: google-fluentd
-      release: stackdriver-tools
-    - name: stackdriver-agent
-      release: stackdriver-tools
-  properties:
-    firehose:
-      endpoint: ${cf_api_url}
-      events_to_stackdriver_logging: LogMessage,Error,HttpStartStop,CounterEvent,ValueMetric,ContainerMetric
-      events_to_stackdriver_monitoring: CounterEvent,ValueMetric,ContainerMetric
-      username: ${firehose_username}
-      password: ${firehose_password}
-      skip_ssl: true
-      newline_token: ∴
-    gcp:
-      project_id: ${cf_project_id}
-    credentials:
-      application_default_credentials: '${cf_service_account_json}'
-    nozzle:
-      debug: true
-
-compilation:
-  workers: 6
-  network: private
-  reuse_compilation_vms: true
-  cloud_properties:
-    zone: ${google_zone}
-    machine_type: n1-standard-8
-    root_disk_size_gb: 100
-    root_disk_type: pd-ssd
-    preemptible: true
-
-resource_pools:
-  - name: common
-    network: private
-    stemcell:
-      name: bosh-google-kvm-ubuntu-trusty-go_agent
-      version: latest
-    cloud_properties:
-      zone: ${google_zone}
-      machine_type: n1-standard-4
-      root_disk_size_gb: 20
-      root_disk_type: pd-standard
-  - name: nozzle
-    network: private
-    stemcell:
-      name: bosh-google-kvm-ubuntu-trusty-go_agent
-      version: latest
-    cloud_properties:
-      zone: ${google_zone}
-      machine_type: n1-standard-4
-      root_disk_size_gb: 20
-      root_disk_type: pd-standard
-
-networks:
-  - name: private
-    type: manual
-    subnets:
-    - range: 192.168.0.0/16
-      reserved:
-      - 192.168.0.0-192.168.1.15
-      gateway: 192.168.0.1
-      cloud_properties:
-        zone: ${google_zone}
-        network_name: ${network}
-        subnetwork_name: ${private_subnetwork}
-        ephemeral_external_ip: false
-        tags:
-          - stackdriver-nozzle-internal
-          - internal
-          - no-ip
-
-update:
-  canaries: 1
-  max_in_flight: 1
-  serial: false
-  canary_watch_time: 1000-60000
-  update_watch_time: 1000-60000
-
-EOF
-
-bosh2 -n deploy ${nozzle_manifest_name} -d ${nozzle_deployment_name}
+bosh2 cloud-config
+bosh2 deploy -n manifests/stackdriver-tools.yml \
+            -d stackdriver-nozzle \
+            --var=firehose_endpoint=${cf_api_url} \
+            --var=firehose_username=${firehose_username} \
+            --var=firehose_password=${firehose_password} \
+            --var=skip_ssl=true \
+            --var=gcp_project_id=${cf_project_id} \
+            --var-file=gcp_service_account_json=/tmp/service_account.json
 
 # Move release and its SHA256
 mv stackdriver-tools-artifacts/*.tgz candidate/latest.tgz

--- a/ci/tasks/deploy-candidate.sh
+++ b/ci/tasks/deploy-candidate.sh
@@ -32,6 +32,9 @@ echo "Configuring SSH"
 echo -e "${ssh_key}" > /tmp/${ssh_user}.key
 chmod 700 /tmp/${ssh_user}.key
 
+echo "Configuring credentials"
+echo "${cf_service_account_json}" > /tmp/service_account.json
+
 echo "Connecting to SSH bastion..."
 ssh -4 -D 5000 -fNC bosh@${ssh_bastion_address} -i /tmp/${ssh_user}.key -o StrictHostKeyChecking=no
 export BOSH_ALL_PROXY=socks5://localhost:5000
@@ -66,12 +69,12 @@ bosh2 cloud-config
 echo "Deploying nozzle release"
 bosh2 deploy -n manifests/stackdriver-tools.yml \
             -d stackdriver-nozzle \
-            --var=firehose_endpoint=${cf_api_url} \
-            --var=firehose_username=${firehose_username} \
-            --var=firehose_password=${firehose_password} \
-            --var=skip_ssl=true \
-            --var=gcp_project_id=${cf_project_id} \
-            --var=gcp_service_account_json=${cf_service_account_json}
+            -v firehose_endpoint=${cf_api_url} \
+            -v firehose_username=${firehose_username} \
+            -v firehose_password=${firehose_password} \
+            -v skip_ssl=true \
+            -v gcp_project_id=${cf_project_id} \
+            --var-file gcp_service_account_json=/tmp/service_account.json
 
 popd
 

--- a/ci/tasks/deploy-candidate.sh
+++ b/ci/tasks/deploy-candidate.sh
@@ -33,6 +33,7 @@ chmod 700 /tmp/${ssh_user}.key
 
 echo "Connecting to SSH bastion..."
 ssh bosh@${ssh_bastion_address} -i /tmp/${ssh_user}.key -o StrictHostKeyChecking=no -L 25555:${bosh_director_address}:25555 -nNT &
+ssh bosh@${ssh_bastion_address} -i /tmp/${ssh_user}.key -o StrictHostKeyChecking=no -L 8443:${bosh_director_address}:8443 -nNT &
 
 echo "Using BOSH CLI version..."
 bosh version

--- a/ci/tasks/deploy-candidate.sh
+++ b/ci/tasks/deploy-candidate.sh
@@ -51,10 +51,11 @@ echo "Uploading nozzle release..."
 bosh2 upload-release stackdriver-tools-artifacts/*.tgz
 
 nozzle_manifest_name=stackdriver-nozzle.yml
+nozzle_deployment_name=stackdriver-nozzle-ci
 cat > ${nozzle_manifest_name} <<EOF
 ---
 
-name: stackdriver-nozzle-ci
+name: ${nozzle_deployment_name}
 
 releases:
 - name: stackdriver-tools
@@ -149,7 +150,7 @@ update:
 
 EOF
 
-bosh2 -n deploy ${nozzle_manifest_name}
+bosh2 -n deploy ${nozzle_manifest_name} -d ${nozzle_deployment_name}
 
 # Move release and its SHA256
 mv stackdriver-tools-artifacts/*.tgz candidate/latest.tgz

--- a/ci/tasks/deploy-candidate.yml
+++ b/ci/tasks/deploy-candidate.yml
@@ -19,6 +19,7 @@ params:
   bosh_director_address: replace-me
   bosh_user:             replace-me
   bosh_password:         replace-me
+  bosh_ca_cert:          replace-me
   cf_deployment_name:    replace-me
 
   # CF settings

--- a/manifests/cloud-config-gcp.yml
+++ b/manifests/cloud-config-gcp.yml
@@ -1,0 +1,51 @@
+# src: https://raw.githubusercontent.com/cloudfoundry/bosh-deployment/master/gcp/cloud-config.yml
+azs:
+- name: z1
+  cloud_properties:
+    zone: ((zone))
+- name: z2
+  cloud_properties:
+    zone: ((zone))
+- name: z3
+  cloud_properties:
+    zone: ((zone))
+
+vm_types:
+- name: default
+  cloud_properties:
+    machine_type: n1-standard-2
+    root_disk_size_gb: 20
+    root_disk_type: pd-ssd
+- name: large
+  cloud_properties:
+    machine_type: n1-standard-4
+    root_disk_size_gb: 50
+    root_disk_type: pd-ssd
+
+disk_types:
+- name: default
+  disk_size: 3000
+- name: large
+  disk_size: 50_000
+
+networks:
+- name: default
+  type: manual
+  subnets:
+  - range: ((internal_cidr))
+    gateway: ((internal_gw))
+    reserved: ((reserved))
+    azs: [z1, z2, z3]
+    dns: [169.254.169.254]
+    cloud_properties:
+      network_name: ((network))
+      subnetwork_name: ((subnetwork))
+      ephemeral_external_ip: true
+      tags: ((tags))
+
+compilation:
+  workers: 1
+  reuse_compilation_vms: true
+  az: z1
+  vm_type: large
+  network: default

--- a/manifests/stackdriver-tools.yml
+++ b/manifests/stackdriver-tools.yml
@@ -1,33 +1,26 @@
 ---
-<%
-director_uuid = ""
-# Endpoint for the Cloud Foundry API (eg: https://api.cf.example.org/)
-firehose_endpoint = ""
-firehose_username = ""
-firehose_password = ""
-# Log/Metric Events to send to Stackdriver
-events_to_stackdriver_logging = "LogMessage,Error,HttpStartStop,CounterEvent,ValueMetric,ContainerMetric"
-events_to_stackdriver_monitoring = "CounterEvent,ValueMetric,ContainerMetric"
-zone = ""
-network_name = ""
-subnetwork_name = ""
-# Skip SSL validation, shortcut for evaluating, do not use in production
-skip_ssl = false
-%>
 name: stackdriver-nozzle
-director_uuid: <%= director_uuid %>
 
 releases:
 - name: stackdriver-tools
   version: latest
 
-jobs:
+# This block does not belong in here or needs to be specialized for GCP in a different way
+stemcells:
+- alias: default
+  name: bosh-google-kvm-ubuntu-trusty-go_agent
+  version: latest
+
+instance_groups:
 - name: stackdriver-nozzle
-  instances: 2
+  instances: 1
   networks:
-  - name: private
-  resource_pool: nozzle_pool
-  templates:
+  - name: default
+  azs: [z1]
+  vm_type: default
+  persistent_disk_type: default
+  stemcell: default
+  jobs:
   - name: stackdriver-nozzle
     release: stackdriver-tools
   - name: google-fluentd
@@ -36,48 +29,16 @@ jobs:
     release: stackdriver-tools
   properties:
     firehose:
-      endpoint: <%= firehose_endpoint %>
-      username: <%= firehose_username %>
-      password: <%= firehose_password %>
-      skip_ssl: <%= skip_ssl %> 
-      events_to_stackdriver_logging: <%= events_to_stackdriver_logging %>
-      events_to_stackdriver_monitoring: <%= events_to_stackdriver_monitoring %>
-
-compilation:
-  workers: 3
-  network: private
-  reuse_compilation_vms: true
-  cloud_properties:
-    zone: <%= zone %>
-    machine_type: n1-standard-8
-    root_disk_size_gb: 100
-    root_disk_type: pd-ssd
-    preemptible: true
-
-resource_pools:
-- name: nozzle_pool
-  network: private
-  stemcell:
-    name: bosh-google-kvm-ubuntu-trusty-go_agent
-    version: latest
-  cloud_properties:
-    zone: <%= zone %>
-    machine_type: n1-standard-4
-    root_disk_size_gb: 20
-    root_disk_type: pd-standard
-    service_account: <%= service_account %>
-
-networks:
-- name: private
-  type: dynamic
-  cloud_properties:
-    zone: <%= zone %>
-    network_name: <%= network_name %>
-    subnetwork_name: <%= subnetwork_name %>
-    ephemeral_external_ip: false
-    tags:
-    - internal
-    - no-ip
+      endpoint: ((firehose_endpoint))
+      username: ((firehose_username))
+      password: ((firehose_password))
+      skip_ssl: ((skip_ssl))
+      events_to_stackdriver_logging: LogMessage,Error,HttpStartStop
+      events_to_stackdriver_monitoring: CounterEvent,ValueMetric,ContainerMetric
+    gcp:
+      project_id: ((gcp_project_id))
+    credentials:
+      application_default_credentials: ((gcp_service_account_json))
 
 update:
   canaries: 1


### PR DESCRIPTION
Updates example manifest to use take advantage of BOSH 2.0. The example manifest is also used in CI for validation. 

Fixes #125, #174

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cloudfoundry-community/stackdriver-tools/188)
<!-- Reviewable:end -->
