### PR TITLE
Use native Google Cloud Storage for release blobs

### DIFF
--- a/config/final.yml
+++ b/config/final.yml
@@ -1,9 +1,6 @@
 ---
 final_name: stackdriver-tools
 blobstore:
-  provider: s3
+  provider: gcs
   options:
     bucket_name: stackdriver-tools-blobs
-    host: storage.googleapis.com
-    use_ssl: true
-    endpoint: https://storage.googleapis.com


### PR DESCRIPTION
Use the GCS provider to fetch blobs. This does not require updates to the blobs because they have always been stored in this bucket.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cloudfoundry-community/stackdriver-tools/189)
<!-- Reviewable:end -->
