### PR TITLE
Remove reduntant metrics.firehose_events.emitted.count metric.

### DIFF
--- a/src/stackdriver-nozzle/stackdriver/metric_adapter.go
+++ b/src/stackdriver-nozzle/stackdriver/metric_adapter.go
@@ -33,13 +33,11 @@ type MetricAdapter interface {
 }
 
 var (
-	timeSeriesCount     *telemetry.Counter
-	firehoseEventsCount *telemetry.Counter
+	timeSeriesCount *telemetry.Counter
 )
 
 func init() {
 	timeSeriesCount = telemetry.NewCounter(telemetry.Nozzle, "metrics.timeseries.count")
-	firehoseEventsCount = telemetry.NewCounter(telemetry.Nozzle, "metrics.firehose_events.emitted.count")
 }
 
 type metricAdapter struct {
@@ -108,7 +106,6 @@ func (ma *metricAdapter) buildTimeSeries(metrics []*messages.Metric) []*monitori
 			continue
 		}
 
-		firehoseEventsCount.Increment()
 		timeSeriesCount.Increment()
 		timeSerieses = append(timeSerieses, metric.TimeSeries())
 	}

--- a/src/stackdriver-nozzle/stackdriver/metric_adapter_test.go
+++ b/src/stackdriver-nozzle/stackdriver/metric_adapter_test.go
@@ -45,7 +45,6 @@ var _ = Describe("MetricAdapter", func() {
 	)
 
 	BeforeEach(func() {
-		firehoseEventsCount.Set(0)
 		timeSeriesCount.Set(0)
 
 		client = &mocks.MockClient{}
@@ -254,11 +253,9 @@ var _ = Describe("MetricAdapter", func() {
 		}
 
 		subject.PostMetrics(metrics)
-		Expect(firehoseEventsCount.IntValue()).To(Equal(3))
 		Expect(timeSeriesCount.IntValue()).To(Equal(3))
 
 		subject.PostMetrics(metrics)
-		Expect(firehoseEventsCount.IntValue()).To(Equal(6))
 		Expect(timeSeriesCount.IntValue()).To(Equal(6))
 	})
 })


### PR DESCRIPTION
It has the same value as `metrics.timeseries.count`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cloudfoundry-community/stackdriver-tools/191)
<!-- Reviewable:end -->
