### PR TITLE
Concurrent in-flight requests to Stackdriver Logging

### DIFF
--- a/jobs/stackdriver-nozzle/spec
+++ b/jobs/stackdriver-nozzle/spec
@@ -53,6 +53,10 @@ properties:
     description: Flush interval (in seconds) of the internal logging buffer
     default: 30
 
+  nozzle.logging_requests_in_flight:
+    description: The maximum permitted number of concurrent in-flight requests to Stackdriver Logging.
+    default: 16
+
   nozzle.debug:
     description: Enable debug features for the stackdriver-nozzle for development or troubleshooting
     default: false

--- a/jobs/stackdriver-nozzle/templates/stackdriver-nozzle-ctl.erb
+++ b/jobs/stackdriver-nozzle/templates/stackdriver-nozzle-ctl.erb
@@ -38,6 +38,7 @@ case $1 in
     export FOUNDATION_NAME=<%= p('nozzle.foundation_name', 'cf') %>
     export LOGGING_BATCH_COUNT=<%= p('nozzle.logging_batch_count', '1000') %>
     export LOGGING_BATCH_DURATION=<%= p('nozzle.logging_batch_duration', '30') %>
+    export LOGGING_REQUESTS_IN_FLIGHT=<%= p('nozzle.logging_requests_in_flight', '16') %>
     export ENABLE_CUMULATIVE_COUNTERS=<%= p('nozzle.enable_cumulative_counters', 'false') %>
     export ENABLE_APP_HTTP_METRICS=<%= p('nozzle.enable_app_http_metrics', 'false') %>
 

--- a/src/stackdriver-nozzle/app/builder.go
+++ b/src/stackdriver-nozzle/app/builder.go
@@ -123,6 +123,7 @@ func (a *App) newLogAdapter() stackdriver.LogAdapter {
 		a.c.ProjectID,
 		a.c.LoggingBatchCount,
 		time.Duration(a.c.LoggingBatchDuration)*time.Second,
+		a.c.LoggingReqsInFlight,
 	)
 	go func() {
 		err := <-logErrs

--- a/src/stackdriver-nozzle/config/config.go
+++ b/src/stackdriver-nozzle/config/config.go
@@ -71,6 +71,7 @@ type Config struct {
 	ProjectID            string `envconfig:"gcp_project_id"`
 	LoggingBatchCount    int    `envconfig:"logging_batch_count" default:"1000"`
 	LoggingBatchDuration int    `envconfig:"logging_batch_duration" default:"30"`
+	LoggingReqsInFlight  int    `envconfig:"logging_requests_in_flight" default:"16"`
 
 	// Nozzle config
 	HeartbeatRate         int    `envconfig:"heartbeat_rate" default:"30"`

--- a/src/stackdriver-nozzle/stackdriver/log_adapter.go
+++ b/src/stackdriver-nozzle/stackdriver/log_adapter.go
@@ -46,7 +46,7 @@ type LogAdapter interface {
 }
 
 // NewLogAdapter returns a LogAdapter that can post to Stackdriver Logging.
-func NewLogAdapter(projectID string, batchCount int, batchDuration time.Duration) (LogAdapter, <-chan error) {
+func NewLogAdapter(projectID string, batchCount int, batchDuration time.Duration, inFlight int) (LogAdapter, <-chan error) {
 	errs := make(chan error)
 	loggingClient, err := logging.NewClient(context.Background(), projectID, option.WithUserAgent(version.UserAgent()))
 	if err != nil {
@@ -61,6 +61,7 @@ func NewLogAdapter(projectID string, batchCount int, batchDuration time.Duration
 	sdLogger := loggingClient.Logger(logId,
 		logging.EntryCountThreshold(batchCount),
 		logging.DelayThreshold(batchDuration),
+		logging.ConcurrentWriteLimit(inFlight),
 	)
 
 	resource := &mrpb.MonitoredResource{

--- a/src/stackdriver-nozzle/vendor/cloud.google.com/go/LICENSE
+++ b/src/stackdriver-nozzle/vendor/cloud.google.com/go/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2014 Google Inc.
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/stackdriver-nozzle/vendor/cloud.google.com/go/logging/doc.go
+++ b/src/stackdriver-nozzle/vendor/cloud.google.com/go/logging/doc.go
@@ -38,7 +38,7 @@ Use a Client to interact with the Stackdriver Logging API.
 
 Basic Usage
 
-For most use-cases, you'll want to add log entries to a buffer to be periodically
+For most use cases, you'll want to add log entries to a buffer to be periodically
 flushed (automatically and asynchronously) to the Stackdriver Logging service.
 
 	// Initialize a logger
@@ -63,9 +63,26 @@ Synchronous Logging
 
 For critical errors, you may want to send your log entries immediately.
 LogSync is slow and will block until the log entry has been sent, so it is
-not recommended for basic use.
+not recommended for normal use.
 
 	lg.LogSync(ctx, logging.Entry{Payload: "ALERT! Something critical happened!"})
+
+
+Payloads
+
+An entry payload can be a string, as in the examples above. It can also be any value
+that can be marshaled to a JSON object, like a map[string]interface{} or a struct:
+
+	type MyEntry struct {
+		Name  string
+		Count int
+	}
+	lg.Log(logging.Entry{Payload: MyEntry{Name: "Bob", Count: 3}})
+
+If you have a []byte of JSON, wrap it in json.RawMessage:
+
+	j := []byte(`{"Name": "Bob", "Count": 3}`)
+	lg.Log(logging.Entry{Payload: json.RawMessage(j)})
 
 
 The Standard Logger Interface
@@ -85,6 +102,16 @@ An Entry may have one of a number of severity levels associated with it.
 		Payload: "something terrible happened!",
 		Severity: logging.Critical,
 	}
+
+
+Viewing Logs
+
+You can view Stackdriver logs for projects at
+https://console.cloud.google.com/logs/viewer. From the dropdown at the top left,
+select "Google Project" and then the project ID. Logs for organizations, folders and
+billing accounts can be viewed on the command line with the "gcloud logging read"
+command.
+
 
 */
 package logging // import "cloud.google.com/go/logging"

--- a/src/stackdriver-nozzle/vendor/cloud.google.com/go/logging/logging.go
+++ b/src/stackdriver-nozzle/vendor/cloud.google.com/go/logging/logging.go
@@ -94,12 +94,12 @@ var ErrOversizedEntry = bundler.ErrOversizedItem
 
 // Client is a Logging client. A Client is associated with a single Cloud project.
 type Client struct {
-	client    *vkit.Client // client for the logging service
-	projectID string
-	errc      chan error     // should be buffered to minimize dropped errors
-	donec     chan struct{}  // closed on Client.Close to close Logger bundlers
-	loggers   sync.WaitGroup // so we can wait for loggers to close
-	closed    bool
+	client  *vkit.Client   // client for the logging service
+	parent  string         // e.g. "projects/proj-id"
+	errc    chan error     // should be buffered to minimize dropped errors
+	donec   chan struct{}  // closed on Client.Close to close Logger bundlers
+	loggers sync.WaitGroup // so we can wait for loggers to close
+	closed  bool
 
 	mu      sync.Mutex
 	nErrs   int   // number of errors we saw
@@ -117,15 +117,20 @@ type Client struct {
 	OnError func(err error)
 }
 
-// NewClient returns a new logging client associated with the provided project ID.
+// NewClient returns a new logging client associated with the provided parent.
+// A parent can take any of the following forms:
+//    projects/PROJECT_ID
+//    folders/FOLDER_ID
+//    billingAccounts/ACCOUNT_ID
+//    organizations/ORG_ID
+// for backwards compatibility, a string with no '/' is also allowed and is interpreted
+// as a project ID.
 //
 // By default NewClient uses WriteScope. To use a different scope, call
 // NewClient using a WithScopes option (see https://godoc.org/google.golang.org/api/option#WithScopes).
-func NewClient(ctx context.Context, projectID string, opts ...option.ClientOption) (*Client, error) {
-	// Check for '/' in project ID to reserve the ability to support various owning resources,
-	// in the form "{Collection}/{Name}", for instance "organizations/my-org".
-	if strings.ContainsRune(projectID, '/') {
-		return nil, errors.New("logging: project ID contains '/'")
+func NewClient(ctx context.Context, parent string, opts ...option.ClientOption) (*Client, error) {
+	if !strings.ContainsRune(parent, '/') {
+		parent = "projects/" + parent
 	}
 	opts = append([]option.ClientOption{
 		option.WithEndpoint(internal.ProdAddr),
@@ -137,11 +142,11 @@ func NewClient(ctx context.Context, projectID string, opts ...option.ClientOptio
 	}
 	c.SetGoogleClientInfo("gccl", version.Repo)
 	client := &Client{
-		client:    c,
-		projectID: projectID,
-		errc:      make(chan error, defaultErrorCapacity), // create a small buffer for errors
-		donec:     make(chan struct{}),
-		OnError:   func(e error) { log.Printf("logging client: %v", e) },
+		client:  c,
+		parent:  parent,
+		errc:    make(chan error, defaultErrorCapacity), // create a small buffer for errors
+		donec:   make(chan struct{}),
+		OnError: func(e error) { log.Printf("logging client: %v", e) },
 	}
 	// Call the user's function synchronously, to make life easier for them.
 	go func() {
@@ -153,16 +158,11 @@ func NewClient(ctx context.Context, projectID string, opts ...option.ClientOptio
 			if fn := client.OnError; fn != nil {
 				fn(err)
 			} else {
-				log.Printf("logging (project ID %q): %v", projectID, err)
+				log.Printf("logging (parent %q): %v", parent, err)
 			}
 		}
 	}()
 	return client, nil
-}
-
-// parent returns the string used in many RPCs to denote the parent resource of the log.
-func (c *Client) parent() string {
-	return "projects/" + c.projectID
 }
 
 var unixZeroTimestamp *tspb.Timestamp
@@ -185,8 +185,8 @@ func (c *Client) Ping(ctx context.Context) error {
 		InsertId:  "ping",            // necessary for the service to dedup these entries.
 	}
 	_, err := c.client.WriteLogEntries(ctx, &logpb.WriteLogEntriesRequest{
-		LogName:  internal.LogPath(c.parent(), "ping"),
-		Resource: globalResource(c.projectID),
+		LogName:  internal.LogPath(c.parent, "ping"),
+		Resource: monitoredResource(c.parent),
 		Entries:  []*logpb.LogEntry{ent},
 	})
 	return err
@@ -279,6 +279,28 @@ func detectResource() *mrpb.MonitoredResource {
 	return detectedResource.pb
 }
 
+var resourceInfo = map[string]struct{ rtype, label string }{
+	"organizations":   {"organization", "organization_id"},
+	"folders":         {"folder", "folder_id"},
+	"projects":        {"project", "project_id"},
+	"billingAccounts": {"billing_account", "account_id"},
+}
+
+func monitoredResource(parent string) *mrpb.MonitoredResource {
+	parts := strings.SplitN(parent, "/", 2)
+	if len(parts) != 2 {
+		return globalResource(parent)
+	}
+	info, ok := resourceInfo[parts[0]]
+	if !ok {
+		return globalResource(parts[1])
+	}
+	return &mrpb.MonitoredResource{
+		Type:   info.rtype,
+		Labels: map[string]string{info.label: parts[1]},
+	}
+}
+
 func globalResource(projectID string) *mrpb.MonitoredResource {
 	return &mrpb.MonitoredResource{
 		Type: "global",
@@ -298,6 +320,15 @@ func CommonLabels(m map[string]string) LoggerOption { return commonLabels(m) }
 type commonLabels map[string]string
 
 func (c commonLabels) set(l *Logger) { l.commonLabels = c }
+
+// ConcurrentWriteLimit determines how many goroutines will send log entries to the
+// underlying service. The default is 1. Set ConcurrentWriteLimit to a higher value to
+// increase throughput.
+func ConcurrentWriteLimit(n int) LoggerOption { return concurrentWriteLimit(n) }
+
+type concurrentWriteLimit int
+
+func (c concurrentWriteLimit) set(l *Logger) { l.bundler.HandlerLimit = int(c) }
 
 // DelayThreshold is the maximum amount of time that an entry should remain
 // buffered in memory before a call to the logging service is triggered. Larger
@@ -368,11 +399,11 @@ func (b bufferedByteLimit) set(l *Logger) { l.bundler.BufferedByteLimit = int(b)
 func (c *Client) Logger(logID string, opts ...LoggerOption) *Logger {
 	r := detectResource()
 	if r == nil {
-		r = globalResource(c.projectID)
+		r = monitoredResource(c.parent)
 	}
 	l := &Logger{
 		client:         c,
-		logName:        internal.LogPath(c.parent(), logID),
+		logName:        internal.LogPath(c.parent, logID),
 		commonResource: r,
 	}
 	// TODO(jba): determine the right context for the bundle handler.
@@ -387,12 +418,14 @@ func (c *Client) Logger(logID string, opts ...LoggerOption) *Logger {
 	for _, opt := range opts {
 		opt.set(l)
 	}
-
 	l.stdLoggers = map[Severity]*log.Logger{}
 	for s := range severityName {
 		l.stdLoggers[s] = log.New(severityWriter{l, s}, "", 0)
 	}
+
 	c.loggers.Add(1)
+	// Start a goroutine that cleans up the bundler, its channel
+	// and the writer goroutines when the client is closed.
 	go func() {
 		defer c.loggers.Done()
 		<-c.donec
@@ -423,7 +456,7 @@ func (c *Client) Close() error {
 	c.loggers.Wait() // wait for all bundlers to flush and close
 	// Now there can be no more errors.
 	close(c.errc) // terminate error goroutine
-	// Prefer logging errors to close errors.
+	// Prefer errors arising from logging to the error returned from Close.
 	err := c.extractErrorInfo()
 	err2 := c.client.Close()
 	if err == nil {
@@ -503,9 +536,8 @@ type Entry struct {
 	// The zero value is Default.
 	Severity Severity
 
-	// Payload must be either a string or something that
-	// marshals via the encoding/json package to a JSON object
-	// (and not any other type of JSON value).
+	// Payload must be either a string, or something that marshals via the
+	// encoding/json package to a JSON object (and not any other type of JSON value).
 	Payload interface{}
 
 	// Labels optionally specifies key/value labels for the log entry.
@@ -534,9 +566,7 @@ type Entry struct {
 	// reading entries. It is an error to set it when writing entries.
 	LogName string
 
-	// Resource is the monitored resource associated with the entry. It is set
-	// by the client when reading entries. It is an error to set it when
-	// writing entries.
+	// Resource is the monitored resource associated with the entry.
 	Resource *mrpb.MonitoredResource
 
 	// Trace is the resource name of the trace associated with the log entry,
@@ -620,13 +650,19 @@ func toProtoStruct(v interface{}) (*structpb.Struct, error) {
 	if s, ok := v.(*structpb.Struct); ok {
 		return s, nil
 	}
-	// v is a Go struct that supports JSON marshalling. We want a Struct
+	// v is a Go value that supports JSON marshalling. We want a Struct
 	// protobuf. Some day we may have a more direct way to get there, but right
-	// now the only way is to marshal the Go struct to JSON, unmarshal into a
+	// now the only way is to marshal the Go value to JSON, unmarshal into a
 	// map, and then build the Struct proto from the map.
-	jb, err := json.Marshal(v)
-	if err != nil {
-		return nil, fmt.Errorf("logging: json.Marshal: %v", err)
+	var jb []byte
+	var err error
+	if raw, ok := v.(json.RawMessage); ok { // needed for Go 1.7 and below
+		jb = []byte(raw)
+	} else {
+		jb, err = json.Marshal(v)
+		if err != nil {
+			return nil, fmt.Errorf("logging: json.Marshal: %v", err)
+		}
 	}
 	var m map[string]interface{}
 	err = json.Unmarshal(jb, &m)
@@ -755,8 +791,8 @@ func toLogEntry(e Entry) (*logpb.LogEntry, error) {
 		Operation:   e.Operation,
 		Labels:      e.Labels,
 		Trace:       e.Trace,
+		Resource:    e.Resource,
 	}
-
 	switch p := e.Payload.(type) {
 	case string:
 		ent.Payload = &logpb.LogEntry_TextPayload{TextPayload: p}

--- a/src/stackdriver-nozzle/vendor/vendor.json
+++ b/src/stackdriver-nozzle/vendor/vendor.json
@@ -39,10 +39,10 @@
 			"revisionTime": "2017-09-07T13:44:44Z"
 		},
 		{
-			"checksumSHA1": "4d0MpRY76M+iwt8yrnWnL+RzRtw=",
+			"checksumSHA1": "WJBH5TFiXNjdmq9l/vsGc0UhZAM=",
 			"path": "cloud.google.com/go/logging",
-			"revision": "1816f0b79338997f0dc2dc43e2b725a8560e80de",
-			"revisionTime": "2017-09-07T13:44:44Z"
+			"revision": "8a6926029c1fa28ad24746f6feb11c90abe6bdce",
+			"revisionTime": "2016-11-03T09:58:51Z"
 		},
 		{
 			"checksumSHA1": "2Hr929XAOiiLE58cFjRcQ/yEkVo=",
@@ -673,10 +673,10 @@
 			"revisionTime": "2017-09-09T00:03:25Z"
 		},
 		{
-			"checksumSHA1": "eHVH24oTjntznqeFbggEeaN3XU8=",
+			"checksumSHA1": "HWIhW/XO2mHu6Flmgnf260tprTU=",
 			"path": "google.golang.org/api/support/bundler",
-			"revision": "b6a02105ec5a446209e9d38557f0e1ac30cacf82",
-			"revisionTime": "2017-09-09T00:03:25Z"
+			"revision": "e771abbff930c1ae3c6e2c35117fc88856f11b2f",
+			"revisionTime": "2018-01-30T22:58:17Z"
 		},
 		{
 			"checksumSHA1": "W24V3U8s386thzZOK6g+EjlKeu0=",

--- a/tile.yml.erb
+++ b/tile.yml.erb
@@ -43,6 +43,7 @@ packages:
         foundation_name: (( .properties.foundation_name.value ))
         logging_batch_count: (( .properties.logging_batch_count.value ))
         logging_batch_duration: (( .properties.logging_batch_duration.value ))
+        logging_requests_in_flight: (( .properties.logging_requests_in_flight.value ))
         debug: (( .properties.debug.value ))
         event_filters:
           blacklist: (( .properties.blacklist.value ))
@@ -108,6 +109,11 @@ forms:
     default: 1000
     label: Logging Batch Count
     description: Batch size for log messages being sent to Stackdriver
+  - name: logging_requests_in_flight
+    type: integer
+    default: 16
+    label: Max In-Flight Logging Requests
+    description: The maximum permitted number of concurrent in-flight requests to Stackdriver Logging.
   - name: metric_path_prefix
     type: string
     default: firehose


### PR DESCRIPTION
Thanks to some great work by @jba we can now have multiple in-flight requests to Stackdriver. This should make Nozzle throughput much less susceptible to latency-induced drops.

This PR pulls in the vendor changes and adds a new config option so that the concurrency limit is tuneable (default: 16).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cloudfoundry-community/stackdriver-tools/193)
<!-- Reviewable:end -->
