### PR TITLE
Custom tiles: update bosh, make timestamp part of version (fix #195)

### DIFF
--- a/scripts/build-docker-env.sh
+++ b/scripts/build-docker-env.sh
@@ -16,8 +16,8 @@ go install github.com/onsi/ginkgo/...
 go get github.com/golang/lint/golint
 
 ## Install Bosh 2 CLI
-BOSH2_VERSION="2.0.45"
-BOSH2_SHA1="bf04be72daa7da0c9bbeda16fda7fc7b2b8af51e"
+BOSH2_VERSION=2.0.48
+BOSH2_SHA1="c807f1938494f4280d65ebbdc863eda3f883d72e"
 
 wget -q -c "https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-${BOSH2_VERSION}-linux-amd64"
 echo "${BOSH2_SHA1}	bosh-cli-${BOSH2_VERSION}-linux-amd64" > "bosh2_${BOSH2_VERSION}_SHA1SUM"

--- a/scripts/custom-tile
+++ b/scripts/custom-tile
@@ -22,7 +22,7 @@ if ! git rev-parse; then
 fi
 cd "$(git rev-parse --show-toplevel)"
 
-export VERSION="0.0.1-custom.$(git rev-parse --short HEAD)"
+export VERSION="0.0.$(date +%s)-custom.$(git rev-parse --short HEAD)"
 export TMP_GOPATH="/tmp/gopath"
 
 usage() {


### PR DESCRIPTION
- Update bosh cli to resolve GCS bucket access issue.
- Make current timestamp part of the tile version, which will ensure
  that the latest built tile has the highest version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cloudfoundry-community/stackdriver-tools/196)
<!-- Reviewable:end -->
