### PR TITLE
Restrict nozzle to a single running instance (fix #190)

### DIFF
--- a/jobs/stackdriver-nozzle/spec
+++ b/jobs/stackdriver-nozzle/spec
@@ -75,7 +75,7 @@ properties:
 
   nozzle.enable_cumulative_counters:
     description: Enable reporting counter events as cumulative Stackdriver metrics. This requires all CounterEvent messages for a given metric to be routed to the same nozzle process (which is the case if you run a single copy of the nozzle).
-    default: false
+    default: true
 
   nozzle.enable_app_http_metrics:
     description: Enable generation of per-app HTTP metrics from HttpStartStop events.

--- a/jobs/stackdriver-nozzle/templates/stackdriver-nozzle-ctl.erb
+++ b/jobs/stackdriver-nozzle/templates/stackdriver-nozzle-ctl.erb
@@ -39,7 +39,7 @@ case $1 in
     export LOGGING_BATCH_COUNT=<%= p('nozzle.logging_batch_count', '1000') %>
     export LOGGING_BATCH_DURATION=<%= p('nozzle.logging_batch_duration', '30') %>
     export LOGGING_REQUESTS_IN_FLIGHT=<%= p('nozzle.logging_requests_in_flight', '16') %>
-    export ENABLE_CUMULATIVE_COUNTERS=<%= p('nozzle.enable_cumulative_counters', 'false') %>
+    export ENABLE_CUMULATIVE_COUNTERS=<%= p('nozzle.enable_cumulative_counters', 'true') %>
     export ENABLE_APP_HTTP_METRICS=<%= p('nozzle.enable_app_http_metrics', 'false') %>
 
     <% if_p('gcp.project_id') do |prop| %>

--- a/tile.yml.erb
+++ b/tile.yml.erb
@@ -22,7 +22,7 @@ packages:
     cpu: 2
     dynamic_ip: 1
     static_ip: 0
-    instances: 2
+    singleton: true
     properties:
       firehose:
         endpoint: (( .properties.firehose_endpoint.value ))


### PR DESCRIPTION
Also, enable cumulative counters by default, which should work fine with
a single nozzle instance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cloudfoundry-community/stackdriver-tools/197)
<!-- Reviewable:end -->
