### PR TITLE
clear-metrics-descriptors: docs and usability

### DIFF
--- a/docs/upgrading_2.0.md
+++ b/docs/upgrading_2.0.md
@@ -5,12 +5,29 @@ These breaking changes provide improved metrics functionality but require the op
 aspects of their project. This will result in irreversible historical data loss and the need to 
 recreate dashboards.
 
-This release of the `stackdriver-nozzle` changes the name, type, and labels of all reported metrics.
+## Stackdriver Monitoring Changes
+All exported metrics have changed in this release.
+
+Metric changes:
+- Metrics derived from the firehose now have the metric origin prefixed to the metric name, e.g. "gorouter.total_requests".
+- Metrics derived from the firehose are now exported under a configurable path prefix, which defaults to "firehose".
+- CounterEvent metrics are now represented as COUNTERs rather than GAUGEs in Stackdriver, so per-second rates can be computed.
+- The nozzle exports its own custom metrics under the "stackdriver-nozzle" prefix.
+
+Label changes:
+- Application, space and organization UUIDs are no longer exported.
+- Resolved application, space and organization names are concatenated into a single "applicationPath" label.
+- The application instance index is now exported.
+- Event envelope tags are now exported as a string of comma-separated key=value pairs.
+- Origin and EventType labels are only attached to logs, not metrics.
+- There is a new "foundation" label that is configurable per nozzle instance, to distinguish between multiple foundations in a GCP / Stackdriver project.
 
 ## Clear Metric Descriptors
 Follow [this guide](../src/stackdriver-nozzle/docs/clear-metrics-descriptors.md) to reset metric descriptors
 for your Stackdriver Monitoring project. This needed is to stay under the default [custom metric descriptor](https://cloud.google.com/monitoring/custom-metrics/) quota.
 Ensure the `stackdriver-nozzle` is not running during this process.
+
+An alternative to this procedure is to provision a new Google Cloud Project and configure the updated `stackdriver-nozzle` release to use it.
 
 ## Singleton Deployment of `stackdriver-nozzle`
 The `stackdriver-nozzle` keeps track of counter metrics to send to Stackdriver Monitoring at the instance level by default. 

--- a/docs/upgrading_2.0.md
+++ b/docs/upgrading_2.0.md
@@ -1,0 +1,28 @@
+# Upgrade Procedure for 2.0
+
+This release of `stackdriver-tools` introduces significant breaking changes for `stackdriver-nozzle` users.
+These breaking changes provide improved metrics functionality but require the operator to reset 
+aspects of their project. This will result in irreversible historical data loss and the need to 
+recreate dashboards.
+
+This release of the `stackdriver-nozzle` changes the name, type, and labels of all reported metrics.
+
+## Clear Metric Descriptors
+Follow [this guide](../src/stackdriver-nozzle/docs/clear-metrics-descriptors.md) to reset metric descriptors
+for your Stackdriver Monitoring project. This needed is to stay under the default [custom metric descriptor](https://cloud.google.com/monitoring/custom-metrics/) quota.
+Ensure the `stackdriver-nozzle` is not running during this process.
+
+## Singleton Deployment of `stackdriver-nozzle`
+The `stackdriver-nozzle` keeps track of counter metrics to send to Stackdriver Monitoring at the instance level by default. 
+If multiple copies of the `stackdriver-nozzle` are reporting the same metrics for a Cloud Foundry deployment they
+will report incorrect data. 
+
+This issue is mitigated by running a single instance of the nozzle. 
+An upstream feature in Loggregator is being [tracked](https://www.pivotaltracker.com/n/projects/993188/stories/154821450) to fix this.
+It is highly recommended that users evaluate running a single instance. This release significantly improves
+performance of the `stackdriver-nozzle` and will reduce the needed footprint compared to earlier releases.
+
+If you find that a single instance is not performing as needed then the manifest setting `nozzle.enable_cumulative_counters` 
+can be set to false. Note this option is not avaliable to tile users and will be removed once the tracked
+issue is resolved. It is also possible to manually shard to multiple nozzle instances by only subscribing
+to specific events (see: `firehose.events_to_stackdriver_monitoring`).

--- a/src/stackdriver-nozzle/docs/clear-metrics-descriptors.md
+++ b/src/stackdriver-nozzle/docs/clear-metrics-descriptors.md
@@ -1,0 +1,47 @@
+# Clearing Project Metric Descriptors
+
+This procedure will delete all custom metric descriptors in your Stackdriver Monitoring project.
+This results in historical data loss and the need to re-create dashboards.
+
+## Prerequisites
+- [Golang 1.9+](https://golang.org/doc/install)
+- [BOSH-CLI 2.0.48+](https://bosh.io/docs/cli-v2.html#install) (if using the `stackdriver-tools` BOSH release)
+- [Google Cloud SDK](https://cloud.google.com/sdk/downloads)
+
+## 1. Authenticate with Google Cloud SDK
+Authenticate with an account that has `roles/monitoring.admin` to the Stackdriver Monitoring project
+and setup your application default credentials.
+
+```bash
+gcloud auth login
+gcloud auth appliaction-default login
+```
+
+## 2. Fetch and build `clear-metrics-descriptors
+```bash
+go get -d github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-nozzle
+GOBIN=`pwd` go install $(go env GOPATH)/src/github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-nozzle/cmd/clear-metrics-descriptors.go
+ls clear-metrics-descriptors
+``` 
+
+## 3. Stop all instance of `stackdriver-nozzle`
+All copies of the `stackdriver-nozzle` need to be completely stopped before proceeding. If an instance
+is left running then old metric descriptors will be recreated.
+
+If you're using the Stackdriver Nozzle tile in Pivotal Operations Manager then follow [these instructions](https://docs.pivotal.io/pivotalcf/2-0/customizing/add-delete.html)
+to delete the product and apply changes to your deployment.
+
+If you're using the `stackdriver-tools` BOSH release, run: `bosh -d <your deployment> --stop stackdriver-nozle`
+
+## 4. Clear Metric Descriptors
+Export the follow environment variable to the name of your Stackdriver Monitoring project:
+```bash
+export GCP_PROJECT_ID=<Your GCP Project ID, eg cf-prod-monitoring-foo>
+```
+
+Execute the `clear-metrics-descriptors` program:
+```bash
+./clear-metrics-descriptors
+```
+
+Your project should now be clear of all custom metric descriptors. You can proceed with upgrading the nozzle.

--- a/src/stackdriver-nozzle/docs/clear-metrics-descriptors.md
+++ b/src/stackdriver-nozzle/docs/clear-metrics-descriptors.md
@@ -39,7 +39,7 @@ Export the follow environment variable to the name of your Stackdriver Monitorin
 export GCP_PROJECT_ID=<Your GCP Project ID, eg cf-prod-monitoring-foo>
 ```
 
-Execute the `clear-metrics-descriptors` program:
+Execute the `clear-metrics-descriptors` program you compiled in step 2:
 ```bash
 ./clear-metrics-descriptors
 ```

--- a/src/stackdriver-nozzle/docs/clear-metrics-descriptors.md
+++ b/src/stackdriver-nozzle/docs/clear-metrics-descriptors.md
@@ -17,11 +17,9 @@ gcloud auth login
 gcloud auth appliaction-default login
 ```
 
-## 2. Fetch and build `clear-metrics-descriptors
+## 2. Fetch `clear-metrics-descriptors`
 ```bash
 go get -d github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-nozzle
-GOBIN=`pwd` go install $(go env GOPATH)/src/github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-nozzle/cmd/clear-metrics-descriptors.go
-ls clear-metrics-descriptors
 ``` 
 
 ## 3. Stop all instance of `stackdriver-nozzle`
@@ -34,14 +32,10 @@ to delete the product and apply changes to your deployment.
 If you're using the `stackdriver-tools` BOSH release, run: `bosh -d <your deployment> --stop stackdriver-nozle`
 
 ## 4. Clear Metric Descriptors
-Export the follow environment variable to the name of your Stackdriver Monitoring project:
+Export the follow environment variable to the name of your Stackdriver Monitoring project and execute the script:
 ```bash
-export GCP_PROJECT_ID=<Your GCP Project ID, eg cf-prod-monitoring-foo>
-```
-
-Execute the `clear-metrics-descriptors` program you compiled in step 2:
-```bash
-./clear-metrics-descriptors
+cd $(go env GOPATH)/src/github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-nozzle/cmd
+go run ./clear-metrics-descriptors.go --project-id <your GCP project, eg cf-prod-logs>
 ```
 
 Your project should now be clear of all custom metric descriptors. You can proceed with upgrading the nozzle.


### PR DESCRIPTION
- Added usability improvements to the clear-metrics-descriptors script.
  This adds a confirmation prompt, presence validation for the
  GCP_PROJECT_ID, and cleaned up output.
- Add specific instructions for clearing out metrics descriptors. This
  doc omits the need to use the develop branch. That's fine- if someone
  does follow these steps today it will work.
- Add general 2.0 upgrade instructions with guidance on singleton
  instance of the nozzle and the need for clear-metrics-descriptors.

updates #185 

/cc @knyar @fluffle

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cloudfoundry-community/stackdriver-tools/198)
<!-- Reviewable:end -->
