### PR TITLE
Add foundation label to result log

### DIFF
--- a/jobs/google-fluentd/spec
+++ b/jobs/google-fluentd/spec
@@ -9,8 +9,13 @@ templates:
   google-fluentd.conf: config/google-fluentd.conf
   syslog.conf: config/config.d/syslog.conf
   vcap.conf: config/config.d/vcap.conf
+  syslog_endpoint.conf.erb: config/config.d/syslog_endpoint.conf
   application_default_credentials.json.erb: config/application_default_credentials.json
 
-properties: 
+properties:
   credentials.application_default_credentials:
       description: Contents of application_default_credentials.json, see https://cloud.google.com/logging/docs/agent/authorization#configuring_client_id_authorization.
+  syslog.bind:
+      description: bind ip address for example 0.0.0.0
+  syslog.port:
+      description: bind port for example 5140

--- a/jobs/google-fluentd/templates/syslog_endpoint.conf.erb
+++ b/jobs/google-fluentd/templates/syslog_endpoint.conf.erb
@@ -1,0 +1,16 @@
+<source>
+  @type syslog
+  port <%= properties.syslog.port %>
+  protocol_type udp
+  bind <%= properties.syslog.bind %>
+  format /(?<message>.*)/
+  tag syslog
+</source>
+<source>
+  @type syslog
+  port <%= properties.syslog.port %>
+  protocol_type tcp
+  bind <%= properties.syslog.bind %>
+  format /(?<message>.*)/
+  tag syslog
+</source>

--- a/src/stackdriver-nozzle/Makefile
+++ b/src/stackdriver-nozzle/Makefile
@@ -11,7 +11,7 @@ build-all:
 # Prepration for tests
 get-deps:
 	# Go lint tool
-	go get github.com/golang/lint/golint
+	go get golang.org/x/lint/golint
 
 	# Simplify cross-compiling
 	go get github.com/mitchellh/gox

--- a/src/stackdriver-spinner/main.go
+++ b/src/stackdriver-spinner/main.go
@@ -30,7 +30,12 @@ func main() {
 		log.Fatal("A GCP project must be specified.")
 	}
 
-	go startSpinner(gcpProj, count, wait)
+	foundation := os.Getenv("FOUNDATION")
+	if len(foundation) == 0 {
+		log.Fatal("A foundation must be specified.")
+	}
+
+	go startSpinner(gcpProj, foundation, count, wait)
 
 	http.HandleFunc("/", func(res http.ResponseWriter, req *http.Request) {
 		fmt.Fprintf(res, "Johny 5 alive!")
@@ -43,7 +48,7 @@ func main() {
 	}
 }
 
-func startSpinner(proj string, count, wait int) {
+func startSpinner(proj, foundation string, count, wait int) {
 	burstInterval := time.Duration(wait) * time.Second
 
 	emitter := cloudfoundry.NewEmitter(os.Stdout, count, 10*time.Millisecond)
@@ -58,7 +63,7 @@ func startSpinner(proj string, count, wait int) {
 			log.Println(err)
 			continue
 		}
-		logger, err := stackdriver.NewLogger(proj)
+		logger, err := stackdriver.NewLogger(proj, foundation)
 
 		msg := stackdriver.Message{
 			GUID:             result.GUID,

--- a/src/stackdriver-spinner/manifest.yml
+++ b/src/stackdriver-spinner/manifest.yml
@@ -9,4 +9,5 @@ applications:
     GOOGLE_APPLICATION_CREDENTIALS: ./credentials.json
     SPINNER_COUNT: 999
     SPINNER_WAIT: 300
-    GCP_PROJECT: <project-name>
+    GCP_PROJECT: gcp-project-here 
+    FOUNDATION: foundation-name-here 

--- a/src/stackdriver-spinner/manifest.yml
+++ b/src/stackdriver-spinner/manifest.yml
@@ -5,7 +5,7 @@ applications:
   memory: 1G
   env:
     GOPACKAGENAME: github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-spinner
-    GOVERSION: go1.8
+    GOVERSION: go1.11.1
     GOOGLE_APPLICATION_CREDENTIALS: ./credentials.json
     SPINNER_COUNT: 999
     SPINNER_WAIT: 300

--- a/src/stackdriver-spinner/stackdriver/logger.go
+++ b/src/stackdriver-spinner/stackdriver/logger.go
@@ -1,14 +1,15 @@
 package stackdriver
 
-
 import (
 	"context"
 	"fmt"
+
 	"cloud.google.com/go/logging"
 )
 
 type Logger struct {
-	client *logging.Client
+	client     *logging.Client
+	foundation string
 }
 
 type Message struct {
@@ -20,18 +21,17 @@ type Message struct {
 }
 
 func (lg *Logger) Publish(message Message) {
-	lg.client.Logger("stackdriver-spinner-logs").Log(logging.Entry{Payload: message})
+	lg.client.Logger("stackdriver-spinner-logs").Log(logging.Entry{Payload: message, Labels: map[string]string{"foundation": lg.foundation}})
 
-
-	if err := lg.client.Close() ; err != nil {
+	if err := lg.client.Close(); err != nil {
 		fmt.Errorf("Failed to close client: %v", err)
 	}
 }
 
-func NewLogger(projectId string) (*Logger, error) {
+func NewLogger(projectId, foundation string) (*Logger, error) {
 	client, err := logging.NewClient(context.Background(), projectId)
 	if err != nil {
 		return nil, fmt.Errorf("creating client: %v", err)
 	}
-	return &Logger{client}, nil
+	return &Logger{client, foundation}, nil
 }

--- a/tile.yml.erb
+++ b/tile.yml.erb
@@ -8,6 +8,9 @@ name: <%=ENV["TILE_NAME"] %>
 label: <%=ENV["TILE_LABEL"] %>
 description: Import your Cloud Foundry logs and metrics into Stackdriver Logging and Monitoring for diagnostics and alerting
 icon_file: gcp_logo.png
+stemcell_criteria:
+  os: 'ubuntu-xenial'
+  version: '97.16'
 packages:
 - name: stackdriver-tools
   type: bosh-release

--- a/tile.yml.erb
+++ b/tile.yml.erb
@@ -9,8 +9,8 @@ label: <%=ENV["TILE_LABEL"] %>
 description: Import your Cloud Foundry logs and metrics into Stackdriver Logging and Monitoring for diagnostics and alerting
 icon_file: gcp_logo.png
 stemcell_criteria:
-  os: 'ubuntu-xenial'
-  version: '97.16'
+  os: 'ubuntu-trusty'
+  version: '3586.42'
 packages:
 - name: stackdriver-tools
   type: bosh-release

--- a/tile.yml.erb
+++ b/tile.yml.erb
@@ -61,6 +61,7 @@ forms:
   - name: firehose_endpoint
     type: string
     label: Cloud Foundry API Endpoint
+    default: (( $runtime.system_api_url ))
   - name: firehose_events_to_stackdriver_logging
     type: string
     default: HttpStartStop,LogMessage,Error


### PR DESCRIPTION
In a multi-foundation set up that centralises stackdriver logging, we need a way to distinguish the spinner result log for each foundation. This commit will add the necessary foundation label to those logs.


Signed-off-by: James Wynne <jwynne@pivotal.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cloudfoundry-community/stackdriver-tools/201)
<!-- Reviewable:end -->
