### PR TITLE
Stackdriver-agent credentials fix

### DIFF
--- a/jobs/stackdriver-agent/templates/collectd-gcm.conf.tmpl
+++ b/jobs/stackdriver-agent/templates/collectd-gcm.conf.tmpl
@@ -58,7 +58,7 @@ LoadPlugin "match_regex"
 <Plugin "write_gcm">
   PrettyPrintJSON false
   <% if_p('credentials.application_default_credentials') do %>
-  CredentialsJSON "/var/vcap/jobs/stackdriver-nozzle/config/application_default_credentials.json"
+  CredentialsJSON "/var/vcap/jobs/stackdriver-agent/config/application_default_credentials.json"
   <% end %>
 </Plugin>
 


### PR DESCRIPTION
The stackdriver agent job should utilize its own credentials file rather than depending on the nozzle to be running as well

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cloudfoundry-community/stackdriver-tools/206)
<!-- Reviewable:end -->
