### PR TITLE
Decrease the retry count from the default 1000

### DIFF
--- a/src/stackdriver-nozzle/cloudfoundry/firehose.go
+++ b/src/stackdriver-nozzle/cloudfoundry/firehose.go
@@ -51,6 +51,7 @@ func (c *firehose) Connect() (<-chan *events.Envelope, <-chan error) {
 
 	refresher := cfClientTokenRefresh{cfClient: c.cfClient}
 	cfConsumer.SetIdleTimeout(time.Duration(30) * time.Second)
+	cfConsumer.SetMaxRetryCount(20)
 	cfConsumer.RefreshTokenFrom(&refresher)
 	return cfConsumer.Firehose(c.subscriptionID, "")
 }


### PR DESCRIPTION
Decreasing the retry count, so that the nozzle fails faster when it can't possibly recover

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cloudfoundry-community/stackdriver-tools/207)
<!-- Reviewable:end -->
