### PR TITLE
update the golint dependency path

### DIFF
--- a/src/stackdriver-nozzle/Makefile
+++ b/src/stackdriver-nozzle/Makefile
@@ -11,7 +11,7 @@ build-all:
 # Prepration for tests
 get-deps:
 	# Go lint tool
-	go get github.com/golang/lint/golint
+	go get golang.org/x/lint/golint
 
 	# Simplify cross-compiling
 	go get github.com/mitchellh/gox


### PR DESCRIPTION
The golint code moved from github.com/golang/lint/golint to goland.org/x/lint/golint

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cloudfoundry-community/stackdriver-tools/210)
<!-- Reviewable:end -->
