### PR TITLE
Remove the duplication of the log message

### DIFF
--- a/src/stackdriver-nozzle/nozzle/log_sink.go
+++ b/src/stackdriver-nozzle/nozzle/log_sink.go
@@ -84,11 +84,14 @@ func (ls *logSink) parseEnvelope(envelope *events.Envelope) messages.Log {
 			// to remain consistent with the protobuf.
 			logMessageMap["message_type"] = logMessage.GetMessageType().String()
 			severity = parseSeverity(logMessage.GetMessageType())
-			logMessageMap["message"] = message
-			payload["logMessage"] = logMessageMap
 
-			// Duplicate the message payload where stackdriver expects it
+			// Put the message payload where stackdriver expects it
 			payload["message"] = message
+
+			// Avoid duplication of the message
+			delete(logMessageMap, "message")
+
+			payload["logMessage"] = logMessageMap
 		}
 	case events.Envelope_Error:
 		errorMessage := envelope.GetError().GetMessage()

--- a/src/stackdriver-nozzle/nozzle/log_sink_test.go
+++ b/src/stackdriver-nozzle/nozzle/log_sink_test.go
@@ -255,7 +255,6 @@ var _ = Describe("LogSink", func() {
 				"eventType": eventType.String(),
 				"logMessage": map[string]interface{}{
 					"message_type": "OUT",
-					"message":      "19400: Success: Go",
 				},
 				"message": "19400: Success: Go",
 				"serviceContext": map[string]interface{}{
@@ -336,7 +335,6 @@ var _ = Describe("LogSink", func() {
 			Expect(payload).To(HaveKeyWithValue("message", expectedMessage))
 			Expect(payload).To(HaveKeyWithValue("logMessage", map[string]interface{}{
 				"message_type": "OUT",
-				"message":      expectedMessage,
 			},
 			))
 		})


### PR DESCRIPTION
The message field in the logMessage payload was being duplicated into the payload.message field where Stackdriver is expecting to find it. There is no reason to have this information duplicated. It increases storage costs and is confusing for people to see the same information twice in search results.

I wrote this pull request to satisfy issue [#209](https://github.com/cloudfoundry-community/stackdriver-tools/issues/209)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cloudfoundry-community/stackdriver-tools/211)
<!-- Reviewable:end -->
