### PR TITLE
Simplify tile configuration

### DIFF
--- a/jobs/stackdriver-nozzle/spec
+++ b/jobs/stackdriver-nozzle/spec
@@ -12,6 +12,10 @@ packages:
   - stackdriver-nozzle
   - common
 
+consumes:
+  - name: reverse_log_proxy
+    type: reverse_log_proxy
+
 properties:
   rlp.address:
     description: Address and port of the Reverse Log Proxy

--- a/jobs/stackdriver-nozzle/templates/stackdriver-nozzle-ctl.erb
+++ b/jobs/stackdriver-nozzle/templates/stackdriver-nozzle-ctl.erb
@@ -21,7 +21,7 @@ case $1 in
     mkdir -p $LOG_DIR
     chown -R vcap:vcap $LOG_DIR
 
-    export RLP_ADDRESS_COLON_PORT=<%= p('rlp.address') %>
+    export RLP_ADDRESS_COLON_PORT=<%= link('reverse_log_proxy').address %>:<%= link('reverse_log_proxy').p('egress.port', 8082) %>
     export RLP_CA_CERT_FILE=$JOB_DIR/config/cacert.pem
     export RLP_CERT_FILE=$JOB_DIR/config/cert.pem
     export RLP_KEY_FILE=$JOB_DIR/config/cert.key

--- a/manifests/stackdriver-tools-bosh-lite.yml
+++ b/manifests/stackdriver-tools-bosh-lite.yml
@@ -22,6 +22,10 @@ jobs:
   templates:
   - name: stackdriver-nozzle
     release: stackdriver-tools
+    consumes:
+      reverse_log_proxy:
+        from: reverse_log_proxy
+        deployment: cf
   - name: google-fluentd
     release: stackdriver-tools
   properties:

--- a/manifests/stackdriver-tools.yml
+++ b/manifests/stackdriver-tools.yml
@@ -23,6 +23,10 @@ instance_groups:
   jobs:
   - name: stackdriver-nozzle
     release: stackdriver-tools
+    consumes:
+      reverse_log_proxy:
+        from: reverse_log_proxy
+        deployment: cf
   - name: google-fluentd
     release: stackdriver-tools
   - name: stackdriver-agent

--- a/scripts/build-custom-tile-docker.sh
+++ b/scripts/build-custom-tile-docker.sh
@@ -17,10 +17,14 @@ bosh2 create-release --force \
   --name="stackdriver-tools" \
   --version "${VERSION}" \
   --tarball="${RELEASE_PATH}"
+echo "Exiting with $?"
 
 export TILE_NAME="stackdriver-nozzle-custom"
 export TILE_LABEL="Stackdriver Nozzle (custom build)"
 erb tile.yml.erb > tile.yml
 tile build "${VERSION}"
+echo "Exiting with $?"
+
 TILE="product/${TILE_NAME}-${VERSION}.pivotal"
 sha256sum "${PWD}/${TILE}"
+echo done

--- a/scripts/custom-tile
+++ b/scripts/custom-tile
@@ -50,9 +50,20 @@ ENV VERSION="${VERSION}" GOPATH="${TMP_GOPATH}" PATH="${PATH}:${TMP_GOPATH}/bin"
 COPY . .
 RUN scripts/build-custom-tile-docker.sh
 __DOCKERFILE__
+
+  # remove previous custom tiles
+  rm -f stackdriver-nozzle-custom*
+
+  # remove previous tile containers and image (safely)
+  docker ps -a | awk '{ if ($2 == "tile") print $1 }' | xargs -r docker rm
+  docker images | cut -d ' ' -f 1 | grep -x tile | xargs -r docker rmi
+
   docker build -t tile . && rm Dockerfile
-  docker run --rm -v "${PWD}:/mnt" tile cp "/tmp/stackdriver-tools/product/stackdriver-nozzle-custom-${VERSION}.pivotal" /mnt
-  docker rmi tile
+
+  TILEDIR=/tmp/stackdriver-tools/product/
+  TILE=stackdriver-nozzle-custom-${VERSION}.pivotal
+
+  docker run -v "${PWD}:/mnt" tile sh -c "cp ${TILEDIR}/${TILE} /mnt && chown ${UID} /mnt/${TILE}"
 }
 
 clean() {

--- a/tile.yml.erb
+++ b/tile.yml.erb
@@ -20,6 +20,8 @@ packages:
     templates:
     - name: stackdriver-nozzle
       release: stackdriver-tools
+      consumes:
+        reverse_log_proxy: {from: reverse_log_proxy, deployment: "(( ..cf.deployment_name ))"}
     memory: 512
     ephemeral_disk: 4096
     cpu: 2
@@ -29,7 +31,6 @@ packages:
     instances: 1
     properties:
       rlp:
-        address: (( .properties.rlp_address.value ))
         ca_cert: (( $ops_manager.ca_certificate ))
         cert: (( .properties.rlp_creds.cert_pem ))
         key: (( .properties.rlp_creds.private_key_pem ))
@@ -64,11 +65,6 @@ forms:
   label: Nozzle Configuration
   description: Configure access properties for the Stackdriver Nozzle here
   properties:
-  - name: rlp_address
-    type: string
-    label: Reverse Log Proxy host and port
-    description: Address and port of the reverse log proxy. The default value works if BOSH DNS is enabled. Otherwise, set this to the IP address of a reverse log proxy VM.
-    default: loggregator-trafficcontroller.service.cf.internal:8082
   - name: rlp_creds
     type: rsa_cert_credentials
     label: rlp_creds

--- a/tile.yml.erb
+++ b/tile.yml.erb
@@ -30,11 +30,11 @@ packages:
     properties:
       rlp:
         address: (( .properties.rlp_address.value ))
-        ca_cert: (( .properties.rlp_cacert.value ))
-        cert: (( .properties.rlp_cert.value ))
-        key: (( .properties.rlp_key.value ))
+        ca_cert: (( $ops_manager.ca_certificate ))
+        cert: (( .properties.rlp_creds.cert_pem ))
+        key: (( .properties.rlp_creds.private_key_pem ))
       firehose:
-        endpoint: (( .properties.firehose_endpoint.value ))
+        endpoint: (( $runtime.system_api_url ))
         events_to_stackdriver_logging: (( .properties.firehose_events_to_stackdriver_logging.value ))
         events_to_stackdriver_monitoring: (( .properties.firehose_events_to_stackdriver_monitoring.value ))
         username: (( .properties.firehose_username.value || ..cf.uaa.stackdriver_nozzle_credentials.identity ))
@@ -66,20 +66,16 @@ forms:
   properties:
   - name: rlp_address
     type: string
-    label: Reverse Log Proxy IP address and port
-  - name: rlp_cacert
-    type: text
-    label: CA certificate of the Reverse Log Proxy
-  - name: rlp_cert
-    type: text
-    label: The TLS certificate for the Reverse Log Proxy, found in the Adapter Rlp Tls section of your PAS tile credentials section
-  - name: rlp_key
-    type:  text
-    label: The TLS key for the Reverse Log Proxy, found in the same place as the cert
-  - name: firehose_endpoint
-    type: string
-    label: Cloud Foundry API Endpoint
-    default: (( $runtime.system_api_url ))
+    label: Reverse Log Proxy host and port
+    description: Address and port of the reverse log proxy. The default value works if BOSH DNS is enabled. Otherwise, set this to the IP address of a reverse log proxy VM.
+    default: loggregator-trafficcontroller.service.cf.internal:8082
+  - name: rlp_creds
+    type: rsa_cert_credentials
+    label: rlp_creds
+    configurable: false
+    default:
+      domains:
+        - 'stackdriver-nozzle'
   - name: firehose_events_to_stackdriver_logging
     type: string
     default: HttpStartStop,LogMessage,Error

--- a/tile.yml.erb
+++ b/tile.yml.erb
@@ -325,4 +325,4 @@ forms:
 
 requires_product_versions:
 - name: cf
-  version: '~> 2.2.0'
+  version: '~> 2.3.0'


### PR DESCRIPTION

* Generate an x509 certificate for RLP's mutual TLS
* Derive the root Certificate Authority
* Add the BOSH DNS hostname for the Reverse Log Proxy as a default value
* Derive the API URL

I've tested this works with the large footprint. I'm currently working on testing this with the small footprint. However, I ran into issues with the small footprint before these changes, so I'm skeptical. We'll see.

I also updated some of the tile building scripts to make it easier for me to develop.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cloudfoundry-community/stackdriver-tools/219)
<!-- Reviewable:end -->
