### PR TITLE
GoDoc fixes to re-enable the linter golint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,12 +36,18 @@ test:
 	go test -v ./...
 
 lint:
-	# Tests for output
 	# Disabling gosec for https://github.com/securego/gosec/issues/267
 	# Disabling vetshadow for https://github.com/golang/go/issues/19490
-	# Disabling maligned because it also affect the config struct. TODO(mattysweeps) re-enable maligned
-	# Disabling golint due to missing comments for now TODO(mattysweeps) fix godoc
-	$(GOPATH)/bin/gometalinter --deadline=300s --disable gosec --disable vetshadow --disable maligned --disable golint --vendor ./...
+	# Disabling maligned because it also affect the config struct. https://github.com/cloudfoundry-community/stackdriver-tools/issues/244
+	# Excluding stackdriver-nozzle's mocks directory. https://github.com/cloudfoundry-community/stackdriver-tools/issues/245
+	$(GOPATH)/bin/gometalinter \
+	--deadline=300s \
+	--disable gosec \
+	--disable vetshadow \
+	--disable maligned \
+	--vendor \
+	--exclude src/stackdriver-nozzle/mocks \
+	./...
 
 get-deps:
 	# For gometalinter linting

--- a/src/stackdriver-nozzle/app/builder.go
+++ b/src/stackdriver-nozzle/app/builder.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cloudfoundry/sonde-go/events"
 )
 
+// App is an instance of the stackdriver-nozzle app.
 type App struct {
 	logger      lager.Logger
 	c           *config.Config
@@ -47,6 +48,7 @@ type App struct {
 	bufferEmpty func() bool
 }
 
+// New constructs a new stackdriver-nozzle app instance.
 func New(c *config.Config, logger lager.Logger) *App {
 	logger.Info("version", lager.Data{"name": version.Name, "release": version.Release(), "user_agent": version.UserAgent()})
 	logger.Info("arguments", c.ToData())

--- a/src/stackdriver-nozzle/app/runner.go
+++ b/src/stackdriver-nozzle/app/runner.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-nozzle/version"
 )
 
+// Run starts the app.
 func Run(ctx context.Context, a *App) {
 	ctx, cancel := context.WithCancel(ctx)
 

--- a/src/stackdriver-nozzle/cloudfoundry/app_info_repository.go
+++ b/src/stackdriver-nozzle/cloudfoundry/app_info_repository.go
@@ -18,10 +18,14 @@ package cloudfoundry
 
 import "github.com/cloudfoundry-community/go-cfclient"
 
+// AppInfoRepository represents a Cloud Foundry application's information.
 type AppInfoRepository interface {
+
+	// GetAppInfo gets the basic information for a CF application.
 	GetAppInfo(string) AppInfo
 }
 
+// AppInfo is the basic information for a CF application.
 type AppInfo struct {
 	AppName   string
 	SpaceGUID string
@@ -30,10 +34,12 @@ type AppInfo struct {
 	OrgName   string
 }
 
+// NewAppInfoRepository creates a new AppInfoRepository given a CF client.
 func NewAppInfoRepository(cfClient *cfclient.Client) AppInfoRepository {
 	return &appInfoRepository{cfClient, map[string]AppInfo{}}
 }
 
+// NullAppInfoRepository creates a new AppInfoRepository with Go default values.
 func NullAppInfoRepository() AppInfoRepository {
 	return &nullAppInfoRepository{}
 }

--- a/src/stackdriver-nozzle/cloudfoundry/firehose.go
+++ b/src/stackdriver-nozzle/cloudfoundry/firehose.go
@@ -25,11 +25,10 @@ import (
 	"github.com/cloudfoundry/sonde-go/events"
 )
 
-type FirehoseHandler interface {
-	HandleEvent(*events.Envelope) error
-}
-
+// Firehose is a connection to Loggregator's Firehose API
 type Firehose interface {
+
+	// Connect creates a channel for reading Firehose events.
 	Connect() (<-chan *events.Envelope, <-chan error)
 }
 
@@ -39,6 +38,7 @@ type firehose struct {
 	subscriptionID string
 }
 
+// NewFirehose constructs a new Firehose.
 func NewFirehose(cfConfig *cfclient.Config, cfClient *cfclient.Client, subscriptionID string) Firehose {
 	return &firehose{cfConfig, cfClient, subscriptionID}
 }
@@ -60,6 +60,7 @@ type cfClientTokenRefresh struct {
 	cfClient *cfclient.Client
 }
 
+// RefreshAuthToken refreshes the CF token used to connect to the Firehose.
 func (ct *cfClientTokenRefresh) RefreshAuthToken() (token string, err error) {
 	return ct.cfClient.GetToken()
 }

--- a/src/stackdriver-nozzle/cloudfoundry/rlp_reader.go
+++ b/src/stackdriver-nozzle/cloudfoundry/rlp_reader.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cloudfoundry/sonde-go/events"
 )
 
+// ReverseLogProxyConfig is the config needed to connect to the Reverse Log Proxy.
 type ReverseLogProxyConfig struct {
 	Address           string
 	ShardID           string
@@ -55,10 +56,7 @@ func (l loggerWrapper) Printf(s string, d ...interface{}) {
 	l.Info(s, data)
 }
 
-type ReverseLogProxyHandler interface {
-	HandleEvent(*events.Envelope) error
-}
-
+// ReverseLogProxy is a connection to Loggregator's Reverse Log Proxy API.
 type ReverseLogProxy interface {
 	Connect() (<-chan *events.Envelope, <-chan error)
 }
@@ -96,6 +94,7 @@ var allSelectors = []*loggregator_v2.Selector{
 	},
 }
 
+// NewReverseLogProxy constructs a new ReverseLogProxy.
 func NewReverseLogProxy(config *ReverseLogProxyConfig, logger lager.Logger) ReverseLogProxy {
 	wrapper := loggerWrapper{Logger: logger}
 	streamConnector := loggregator.NewEnvelopeStreamConnector(

--- a/src/stackdriver-nozzle/config/config.go
+++ b/src/stackdriver-nozzle/config/config.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pkg/errors"
 )
 
+// NewConfig constructs the configuration struct for the nozzle.
 func NewConfig() (*Config, error) {
 	var c Config
 	err := envconfig.Process("", &c)
@@ -56,6 +57,8 @@ func NewConfig() (*Config, error) {
 	return &c, nil
 }
 
+// Config is the configuration struct for the nozzle.
+// It contains information needed for connecting to CF and Stackdriver endpoints.
 type Config struct {
 	// Firehose config
 	APIEndpoint      string `envconfig:"firehose_endpoint" required:"true"`
@@ -154,6 +157,7 @@ func (r EventFilterRule) String() string {
 	return fmt.Sprintf("%s.%s matches %q", r.Sink, r.Type, r.Regexp)
 }
 
+// EventFilterJSON are a collection of EventFilterRules for a firehose connection.
 type EventFilterJSON struct {
 	Blacklist []EventFilterRule `json:"blacklist,omitempty"`
 	Whitelist []EventFilterRule `json:"whitelist,omitempty"`
@@ -204,6 +208,7 @@ func (c *Config) setNozzleHostInfo() {
 	}
 }
 
+// ToData converts a Config to a lager.Data.
 func (c *Config) ToData() lager.Data {
 	return lager.Data{
 		"APIEndpoint":                   c.APIEndpoint,

--- a/src/stackdriver-nozzle/messages/log.go
+++ b/src/stackdriver-nozzle/messages/log.go
@@ -18,6 +18,7 @@ package messages
 
 import "cloud.google.com/go/logging"
 
+// Log represents a Stackdriver log message.
 type Log struct {
 	Payload  interface{}
 	Labels   map[string]string

--- a/src/stackdriver-nozzle/messages/metric.go
+++ b/src/stackdriver-nozzle/messages/metric.go
@@ -42,7 +42,7 @@ type Metric struct {
 	Type      events.Envelope_EventType `json:"-"`
 }
 
-func (m *Metric) IsCumulative() bool {
+func (m *Metric) isCumulative() bool {
 	return m.Type == events.Envelope_CounterEvent
 }
 
@@ -51,14 +51,14 @@ func (m *Metric) metricType() string {
 }
 
 func (m *Metric) metricKind() metric.MetricDescriptor_MetricKind {
-	if m.IsCumulative() {
+	if m.isCumulative() {
 		return metric.MetricDescriptor_CUMULATIVE
 	}
 	return metric.MetricDescriptor_GAUGE
 }
 
 func (m *Metric) valueType() metric.MetricDescriptor_ValueType {
-	if m.IsCumulative() {
+	if m.isCumulative() {
 		return metric.MetricDescriptor_INT64
 	}
 	return metric.MetricDescriptor_DOUBLE
@@ -67,7 +67,7 @@ func (m *Metric) valueType() metric.MetricDescriptor_ValueType {
 // NeedsMetricDescriptor determines whether a custom metric descriptor needs to be created for this metric in Stackdriver.
 // We do that if we need to set a custom unit, or mark metric as a cumulative.
 func (m *Metric) NeedsMetricDescriptor() bool {
-	return m.Unit != "" || m.IsCumulative()
+	return m.Unit != "" || m.isCumulative()
 }
 
 // MetricDescriptor returns a Stackdriver MetricDescriptor proto for this metric.
@@ -97,7 +97,7 @@ func (m *Metric) MetricDescriptor(projectName string) *metric.MetricDescriptor {
 // TimeSeries returns a Stackdriver TimeSeries proto for this metric value.
 func (m *Metric) TimeSeries() *monitoring.TimeSeries {
 	var value *monitoring.TypedValue
-	if m.IsCumulative() {
+	if m.isCumulative() {
 		value = &monitoring.TypedValue{Value: &monitoring.TypedValue_Int64Value{Int64Value: m.IntValue}}
 	} else {
 		value = &monitoring.TypedValue{Value: &monitoring.TypedValue_DoubleValue{DoubleValue: m.Value}}
@@ -121,6 +121,7 @@ func (m *Metric) TimeSeries() *monitoring.TimeSeries {
 	}
 }
 
+// Hash returns a string identifier for a metric.
 func (m *Metric) Hash() string {
 	var b bytes.Buffer
 

--- a/src/stackdriver-nozzle/metricspipeline/buffer.go
+++ b/src/stackdriver-nozzle/metricspipeline/buffer.go
@@ -18,7 +18,10 @@ package metricspipeline
 
 import "github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-nozzle/stackdriver"
 
+// MetricsBuffer is a buffered MetricAdapter.
 type MetricsBuffer interface {
 	stackdriver.MetricAdapter
+
+	// IsEmpty checks if the buffer is empty.
 	IsEmpty() bool
 }

--- a/src/stackdriver-nozzle/nozzle/filter_sink.go
+++ b/src/stackdriver-nozzle/nozzle/filter_sink.go
@@ -39,6 +39,7 @@ type filter struct {
 	destination          Sink
 }
 
+// NewFilterSink creates a Sink which filters events for another Sink.
 func NewFilterSink(eventNames []events.Envelope_EventType, blacklist, whitelist *EventFilter, destination Sink) (Sink, error) {
 	if destination == nil {
 		return nil, errors.New("missing destinationSink")

--- a/src/stackdriver-nozzle/nozzle/label_maker.go
+++ b/src/stackdriver-nozzle/nozzle/label_maker.go
@@ -27,11 +27,13 @@ import (
 	"github.com/cloudfoundry/sonde-go/events"
 )
 
+// LabelMaker creates Stackdriver labels for logs or metrics.
 type LabelMaker interface {
 	MetricLabels(*events.Envelope, bool) map[string]string
 	LogLabels(*events.Envelope) map[string]string
 }
 
+// NewLabelMaker constructs a new LabelMaker.
 func NewLabelMaker(appInfoRepository cloudfoundry.AppInfoRepository, foundationName string) LabelMaker {
 	return &labelMaker{
 		appInfoRepository: appInfoRepository,

--- a/src/stackdriver-nozzle/nozzle/metric_sink.go
+++ b/src/stackdriver-nozzle/nozzle/metric_sink.go
@@ -28,7 +28,7 @@ import (
 	"github.com/cloudfoundry/sonde-go/events"
 )
 
-// NewLogSink returns a Sink that can receive sonde Events, translate them and send them to a stackdriver.MetricAdapter
+// NewMetricSink returns a Sink that can receive sonde Events, translate them and send them to a stackdriver.MetricAdapter
 func NewMetricSink(logger lager.Logger, pathPrefix string, labelMaker LabelMaker, metricAdapter stackdriver.MetricAdapter, ct *CounterTracker, unitParser UnitParser, runtimeMetricRegex string) (Sink, error) {
 	r, err := regexp.Compile(runtimeMetricRegex)
 	if err != nil {

--- a/src/stackdriver-nozzle/nozzle/nozzle.go
+++ b/src/stackdriver-nozzle/nozzle/nozzle.go
@@ -31,8 +31,13 @@ import (
 
 const bufferSize = 30000 // 1k messages/second * 30 seconds
 
+// Nozzle forwards CF logs and metrics to Stackdriver.
 type Nozzle interface {
+
+	// Start starts the nozzle.
 	Start(rlp cloudfoundry.ReverseLogProxy)
+
+	// Stop stops the nozzle.
 	Stop() error
 }
 
@@ -76,6 +81,7 @@ type state struct {
 	running bool
 }
 
+// NewNozzle creates a new Nozzle.
 func NewNozzle(logger lager.Logger, sinks ...Sink) Nozzle {
 	return &nozzle{
 		sinks:  sinks,

--- a/src/stackdriver-nozzle/nozzle/parse_events.go
+++ b/src/stackdriver-nozzle/nozzle/parse_events.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cloudfoundry/sonde-go/events"
 )
 
+// ParseEvents creates Envelope_EventType from a list of sonde event types.
 func ParseEvents(names []string) ([]events.Envelope_EventType, error) {
 	var parsedEvents []events.Envelope_EventType
 

--- a/src/stackdriver-nozzle/nozzle/sink.go
+++ b/src/stackdriver-nozzle/nozzle/sink.go
@@ -18,6 +18,9 @@ package nozzle
 
 import "github.com/cloudfoundry/sonde-go/events"
 
+// Sink handles sonde events.
 type Sink interface {
+
+	// Receive handles a single sonde event.
 	Receive(*events.Envelope)
 }

--- a/src/stackdriver-nozzle/nozzle/unit_parser.go
+++ b/src/stackdriver-nozzle/nozzle/unit_parser.go
@@ -37,10 +37,14 @@ Component = [ PREFIX ] UNIT [ Annotation ]
 Annotation = "{" NAME "}" ;
 */
 
+// UnitParser parses Sonde metric unit strings to their Stackdriver equivalents.
 type UnitParser interface {
+
+	// Parse converts a Sonde metric unit to a Stackdriver metric unit.
 	Parse(string) string
 }
 
+// NewUnitParser constructs a new UnitParser.
 func NewUnitParser() UnitParser {
 	componentRegex := regexp.MustCompile(fmt.Sprintf("^(%s)?(%s)$", prefixRegex, unitRegex))
 	annotationRegex := regexp.MustCompile("[{}]")

--- a/src/stackdriver-nozzle/stackdriver/log_adapter.go
+++ b/src/stackdriver-nozzle/stackdriver/log_adapter.go
@@ -40,8 +40,13 @@ func init() {
 	logsCount = telemetry.NewCounter(telemetry.Nozzle, "logs.count")
 }
 
+// LogAdapter represents a connection to the Stackdriver Logging API.
 type LogAdapter interface {
+
+	// PostLog sends a log to Stackdriver.
 	PostLog(*messages.Log)
+
+	// Flush performs a flush of all cached logs.
 	Flush() error
 }
 
@@ -82,7 +87,6 @@ type logAdapter struct {
 	resource *mrpb.MonitoredResource
 }
 
-// PostLog sends a single message to Stackdriver Logging
 func (s *logAdapter) PostLog(log *messages.Log) {
 	logsCount.Increment()
 	entry := logging.Entry{

--- a/src/stackdriver-nozzle/stackdriver/metric_adapter.go
+++ b/src/stackdriver-nozzle/stackdriver/metric_adapter.go
@@ -28,7 +28,10 @@ import (
 	"google.golang.org/genproto/googleapis/monitoring/v3"
 )
 
+// MetricAdapter is an adapter to the Stackdriver metrics API.
 type MetricAdapter interface {
+
+	// PostMetrics posts metrics to Stackdriver.
 	PostMetrics([]*messages.Metric)
 }
 
@@ -49,7 +52,7 @@ type metricAdapter struct {
 	logger                lager.Logger
 }
 
-// NewMetricAdapter returns a MetricAdapater that can write to Stackdriver Monitoring
+// NewMetricAdapter returns a MetricAdapter for posting metrics to Stackdriver Monitoring.
 func NewMetricAdapter(projectID string, client MetricClient, batchSize int, logger lager.Logger) (MetricAdapter, error) {
 	ma := &metricAdapter{
 		projectID:             projectID,

--- a/src/stackdriver-nozzle/stackdriver/metric_client.go
+++ b/src/stackdriver-nozzle/stackdriver/metric_client.go
@@ -51,12 +51,20 @@ func init() {
 	descriptorErrs = telemetry.NewCounter(telemetry.Nozzle, "metrics.descriptor.errors")
 }
 
+// MetricClient is a connection to Stackdriver Metrics.
 type MetricClient interface {
+
+	// Post posts a time series point to Stackdriver.
 	Post(*monitoringpb.CreateTimeSeriesRequest) error
+
+	// CreateMetricDescriptor creates a custom metric descriptor.
 	CreateMetricDescriptor(*monitoringpb.CreateMetricDescriptorRequest) error
+
+	// ListMetricDescriptors lists the metric descriptors for a Stackdriver project.
 	ListMetricDescriptors(*monitoringpb.ListMetricDescriptorsRequest) ([]*metricpb.MetricDescriptor, error)
 }
 
+// NewMetricClient constructs a new MetricClient.
 func NewMetricClient() (MetricClient, error) {
 	ctx := context.Background()
 	sdMetricClient, err := monitoring.NewMetricClient(ctx, option.WithScopes("https://www.googleapis.com/auth/monitoring.write"), option.WithUserAgent(version.UserAgent()))

--- a/src/stackdriver-nozzle/version/version.go
+++ b/src/stackdriver-nozzle/version/version.go
@@ -16,6 +16,7 @@
 
 package version
 
+// Name is the string label for the stackdriver-nozzle.
 const Name = "cf-stackdriver-nozzle"
 
 var release string
@@ -27,10 +28,13 @@ func init() {
 	}
 }
 
+// Release returns the version of the BOSH release.
 func Release() string {
 	return release
 }
 
+// UserAgent returns the user agent string to use for identifying connections to Stackdriver
+// from the nozzle.
 func UserAgent() string {
 	return Name + "/" + release
 }

--- a/src/stackdriver-spinner/cloudfoundry/emitter.go
+++ b/src/stackdriver-spinner/cloudfoundry/emitter.go
@@ -19,25 +19,26 @@ package cloudfoundry
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-spinner/session"
 	"io"
 	"time"
 )
 
-type Emitter struct {
+type emitter struct {
 	writer io.Writer
 	count  int
 	delay  time.Duration
 }
 
-type Payload struct {
+type payload struct {
 	Timestamp string `json:"timestamp"`
 	GUID      string `json:"guid"`
 	Count     int    `json:"count"`
 }
 
-func (e *Emitter) Emit(guid string) (int, error) {
+func (e *emitter) Emit(guid string) (int, error) {
 	for i := 0; i < e.count; i++ {
-		pl := Payload{
+		pl := payload{
 			Timestamp: time.Now().UTC().Format("2006-01-02T15:04:05.000-07:00"),
 			GUID:      guid,
 			Count:     i + 1,
@@ -57,6 +58,7 @@ func (e *Emitter) Emit(guid string) (int, error) {
 	return e.count, nil
 }
 
-func NewEmitter(writer io.Writer, count int, delay time.Duration) *Emitter {
-	return &Emitter{writer, count, delay}
+// NewEmitter constructs a new session.Emitter.
+func NewEmitter(writer io.Writer, count int, delay time.Duration) session.Emitter {
+	return &emitter{writer, count, delay}
 }

--- a/src/stackdriver-spinner/cloudfoundry/emitter_test.go
+++ b/src/stackdriver-spinner/cloudfoundry/emitter_test.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Emitter", func() {
+var _ = Describe("emitter", func() {
 	It("logs to stdout once", func() {
 		mockWriter := fakes.Writer{}
 

--- a/src/stackdriver-spinner/fakes/probe.go
+++ b/src/stackdriver-spinner/fakes/probe.go
@@ -18,17 +18,21 @@ package fakes
 
 import "time"
 
+// LosslessProbe never loses any logs.
 type LosslessProbe struct {
 }
 
+// Find finds all logs.
 func (m *LosslessProbe) Find(start time.Time, needle string, count int) (int, error) {
 	return count, nil
 }
 
+// ConfigurableProbe is a logging probe which can return a configurable number of logs.
 type ConfigurableProbe struct {
 	FindFunc func(time.Time, string, int) (int, error)
 }
 
+// Find returns whatever FindFunc determines.
 func (m *ConfigurableProbe) Find(start time.Time, needle string, count int) (int, error) {
 	return m.FindFunc(start, needle, count)
 }

--- a/src/stackdriver-spinner/fakes/writers.go
+++ b/src/stackdriver-spinner/fakes/writers.go
@@ -16,20 +16,24 @@
 
 package fakes
 
+// Writer is an io.Writer which records every write and always returns success.
 type Writer struct {
 	Writes []string
 }
 
+// Write records every write and always returns success.
 func (m *Writer) Write(p []byte) (n int, err error) {
 	m.Writes = append(m.Writes, string(p))
 
 	return len(p), nil
 }
 
+// FailingWriter is an io.Writer which always fails with a configurable error.
 type FailingWriter struct {
 	Err error
 }
 
+// Write always fails.
 func (f *FailingWriter) Write(p []byte) (n int, err error) {
 	return 0, f.Err
 }

--- a/src/stackdriver-spinner/main.go
+++ b/src/stackdriver-spinner/main.go
@@ -95,6 +95,5 @@ func startSpinner(proj, foundation string, count, wait int) {
 		}
 
 		logger.Publish(msg)
-
 	}
 }

--- a/src/stackdriver-spinner/stackdriver/logger.go
+++ b/src/stackdriver-spinner/stackdriver/logger.go
@@ -23,11 +23,13 @@ import (
 	"cloud.google.com/go/logging"
 )
 
+// Logger is a spinner logging client.
 type Logger struct {
 	client     *logging.Client
 	foundation string
 }
 
+// Message is the structure of a spinner log.
 type Message struct {
 	GUID             string  `json:"guid"`
 	NumberSent       int     `json:"number_sent"`
@@ -36,14 +38,16 @@ type Message struct {
 	LossPercentage   float64 `json:"loss_percentage"`
 }
 
+// Publish logs a log message to Stackdriver.
 func (lg *Logger) Publish(message Message) {
 	lg.client.Logger("stackdriver-spinner-logs").Log(logging.Entry{Payload: message, Labels: map[string]string{"foundation": lg.foundation}})
 
 	if err := lg.client.Close(); err != nil {
-		panic(fmt.Errorf("Failed to close client: %v", err))
+		panic(fmt.Errorf("failed to close client: %v", err))
 	}
 }
 
+// NewLogger constructs a new Stackdriver Logger client.
 func NewLogger(projectID, foundation string) (*Logger, error) {
 	client, err := logging.NewClient(context.Background(), projectID)
 	if err != nil {

--- a/src/stackdriver-spinner/stackdriver/logging_probe.go
+++ b/src/stackdriver-spinner/stackdriver/logging_probe.go
@@ -19,6 +19,7 @@ package stackdriver
 import (
 	"context"
 	"fmt"
+	"github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-spinner/session"
 	"time"
 
 	"cloud.google.com/go/logging"
@@ -26,11 +27,11 @@ import (
 	"google.golang.org/api/iterator"
 )
 
-type LoggingProbe struct {
+type loggingProbe struct {
 	client *logadmin.Client
 }
 
-func (lp *LoggingProbe) Find(start time.Time, needle string, count int) (int, error) {
+func (lp *loggingProbe) Find(start time.Time, needle string, count int) (int, error) {
 	timeBytes, err := start.MarshalText()
 	if err != nil {
 		return 0, fmt.Errorf("problem marshaling text: %v", err)
@@ -61,10 +62,11 @@ func (lp *LoggingProbe) Find(start time.Time, needle string, count int) (int, er
 	return len(entries), nil
 }
 
-func NewLoggingProbe(projectID string) (*LoggingProbe, error) {
+// NewLoggingProbe constructs a loggingProbe for a given GCP project.
+func NewLoggingProbe(projectID string) (session.Probe, error) {
 	client, err := logadmin.NewClient(context.Background(), projectID)
 	if err != nil {
 		return nil, fmt.Errorf("creating client: %v", err)
 	}
-	return &LoggingProbe{client}, nil
+	return &loggingProbe{client}, nil
 }


### PR DESCRIPTION
The purpose of this PR is to re-enable the `golint` linter as part of the CI process.
The reason it has been disabled is missing GoDoc.

This PR fixes GoDoc for:
* example app
* spinner
* nozzle

The `src/stackdriver-nozzle/mocks` packaged is excluded from linting for now. An Issue has been opened to explore better solutions: https://github.com/cloudfoundry-community/stackdriver-tools/issues/245

In some cases, variables which didn't need to be exported are no longer exported.

 I also removed the example app's `/info` endpoint. I do not think it was being used by any health checks.