### PR TITLE
Remove old TODOs

### DIFF
--- a/ci/tasks/build-bosh-release.yml
+++ b/ci/tasks/build-bosh-release.yml
@@ -19,7 +19,6 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    # TODO mattysweeps: https://github.com/cloudfoundry-community/stackdriver-tools/issues/223
     repository: cfplatformeng/tile-generator
 inputs:
   - name: stackdriver-tools-source

--- a/ci/tasks/build-tile.yml
+++ b/ci/tasks/build-tile.yml
@@ -19,7 +19,6 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    # TODO mattysweeps: https://github.com/cloudfoundry-community/stackdriver-tools/issues/223
     repository: cfplatformeng/tile-generator
 inputs:
   - name: stackdriver-tools-source

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -15,7 +15,6 @@
 #
 # Dockerfile for building BOSH release and PCF Tile
 
-# TODO mattysweeps: https://github.com/cloudfoundry-community/stackdriver-tools/issues/223
 FROM cfplatformeng/tile-generator:latest
 
 # musl-dev needed for ld: https://bugs.alpinelinux.org/issues/6628


### PR DESCRIPTION
These TODOs were to update the docker image m0pt0pmatt/tile-generator
to cfplatformeng/tile-generator. This has been done, but the TODOs were
left behind.