### PR TITLE
Make cf app metadata cache configurable

### DIFF
--- a/jobs/stackdriver-nozzle/spec
+++ b/jobs/stackdriver-nozzle/spec
@@ -81,6 +81,10 @@ properties:
     description: Enable resolution of app metadata from appGuid
     default: true
 
+  nozzle.app_info_cache_period:
+    description: The amount of time to retain cached info about an app; -1 "caches" permanently; 0 indicates no caching; positive int caches for supplied number of seconds
+    default: -1
+
   nozzle.metric_path_prefix:
     description: Prefix added to all metric names being sent to Stackdriver, e.g. 'custom/PREFIX/gorouter.total_requests'. May contain slashes.
     default: firehose

--- a/jobs/stackdriver-nozzle/templates/stackdriver-nozzle-ctl.erb
+++ b/jobs/stackdriver-nozzle/templates/stackdriver-nozzle-ctl.erb
@@ -39,6 +39,7 @@ case $1 in
 
     export DEBUG_NOZZLE=<%= p('nozzle.debug', 'false') %>
     export RESOLVE_APP_METADATA=<%= p('nozzle.resolve_app_metadata', 'true') %>
+    export APP_INFO_CACHE_PERIOD=<%= p('nozzle.app_info_cache_period', '-1') %>
     export METRICS_BUFFER_DURATION=<%= p('nozzle.metrics_buffer_duration', '30') %>
     export METRICS_BATCH_SIZE=<%= p('nozzle.metrics_batch_size', '200') %>
     export METRIC_PATH_PREFIX=<%= p('nozzle.metric_path_prefix', 'firehose') %>

--- a/src/stackdriver-nozzle/app/builder.go
+++ b/src/stackdriver-nozzle/app/builder.go
@@ -65,7 +65,7 @@ func New(c *config.Config, logger lager.Logger) *App {
 
 	var appInfoRepository cloudfoundry.AppInfoRepository
 	if c.ResolveAppMetadata {
-		appInfoRepository = cloudfoundry.NewAppInfoRepository(cfClient)
+		appInfoRepository = cloudfoundry.NewAppInfoRepository(cfClient, c.AppMetadataCachePeriod)
 	} else {
 		appInfoRepository = cloudfoundry.NullAppInfoRepository()
 	}

--- a/src/stackdriver-nozzle/cloudfoundry/app_info_repository.go
+++ b/src/stackdriver-nozzle/cloudfoundry/app_info_repository.go
@@ -16,7 +16,11 @@
 
 package cloudfoundry
 
-import "github.com/cloudfoundry-community/go-cfclient"
+import (
+	"github.com/cloudfoundry-community/go-cfclient"
+	"math/rand"
+	"time"
+)
 
 // AppInfoRepository represents a Cloud Foundry application's information.
 type AppInfoRepository interface {
@@ -27,16 +31,17 @@ type AppInfoRepository interface {
 
 // AppInfo is the basic information for a CF application.
 type AppInfo struct {
-	AppName   string
-	SpaceGUID string
-	SpaceName string
-	OrgGUID   string
-	OrgName   string
+	AppName     string
+	SpaceGUID   string
+	SpaceName   string
+	OrgGUID     string
+	OrgName     string
+	LastQueried time.Time
 }
 
 // NewAppInfoRepository creates a new AppInfoRepository given a CF client.
-func NewAppInfoRepository(cfClient *cfclient.Client) AppInfoRepository {
-	return &appInfoRepository{cfClient, map[string]AppInfo{}}
+func NewAppInfoRepository(cfClient *cfclient.Client, appMetadataCachePeriod int) AppInfoRepository {
+	return &appInfoRepository{cfClient, map[string]AppInfo{}, appMetadataCachePeriod}
 }
 
 // NullAppInfoRepository creates a new AppInfoRepository with Go default values.
@@ -45,24 +50,49 @@ func NullAppInfoRepository() AppInfoRepository {
 }
 
 type appInfoRepository struct {
-	cfClient *cfclient.Client
-	cache    map[string]AppInfo
+	cfClient               *cfclient.Client
+	cache                  map[string]AppInfo
+	appMetadataCachePeriod int
 }
 
 func (air *appInfoRepository) GetAppInfo(guid string) AppInfo {
-	appInfo, ok := air.cache[guid]
-	if !ok {
-		app, err := air.cfClient.AppByGuid(guid)
-		if err == nil {
-			appInfo = AppInfo{
-				AppName:   app.Name,
-				SpaceGUID: app.SpaceData.Entity.Guid,
-				SpaceName: app.SpaceData.Entity.Name,
-				OrgGUID:   app.SpaceData.Entity.OrgData.Entity.Guid,
-				OrgName:   app.SpaceData.Entity.OrgData.Entity.Name,
+	// Handle cacheable configurations
+	if air.appMetadataCachePeriod != 0 {
+		appInfo, ok := air.cache[guid]
+
+		if ok {
+			if air.appMetadataCachePeriod > 0 {
+				metadataReadTime := appInfo.LastQueried
+				// elapsedTime is in seconds, time.Since returns a duration, so we need to convert to seconds
+				elapsedTime := time.Since(metadataReadTime).Seconds()
+				// adjust ttl to be 75-125% of requested value to help ensure cache evictions are spread out and the cf api doesn't get hit all at once
+				adjustedTtl := float64(air.appMetadataCachePeriod) * (0.75 + (rand.Float64() / 2.0))
+
+				if elapsedTime < adjustedTtl {
+					return appInfo
+				}
+			} else {
+				return appInfo
 			}
-			air.cache[guid] = appInfo
 		}
+	}
+
+	return air.QueryCfForMetadata(guid)
+}
+
+func (air *appInfoRepository) QueryCfForMetadata(guid string) AppInfo {
+	var appInfo AppInfo
+	app, err := air.cfClient.AppByGuid(guid)
+	if err == nil {
+		appInfo := AppInfo{
+			AppName:     app.Name,
+			SpaceGUID:   app.SpaceData.Entity.Guid,
+			SpaceName:   app.SpaceData.Entity.Name,
+			OrgGUID:     app.SpaceData.Entity.OrgData.Entity.Guid,
+			OrgName:     app.SpaceData.Entity.OrgData.Entity.Name,
+			LastQueried: time.Now(),
+		}
+		air.cache[guid] = appInfo
 	}
 	return appInfo
 }

--- a/src/stackdriver-nozzle/config/config.go
+++ b/src/stackdriver-nozzle/config/config.go
@@ -86,16 +86,17 @@ type Config struct {
 	LoggingReqsInFlight  int    `envconfig:"logging_requests_in_flight" default:"16"`
 
 	// Nozzle config
-	HeartbeatRate         int    `envconfig:"heartbeat_rate" default:"30"`
-	MetricsBufferDuration int    `envconfig:"metrics_buffer_duration" default:"30"`
-	MetricsBatchSize      int    `envconfig:"metrics_batch_size" default:"200"`
-	MetricPathPrefix      string `envconfig:"metric_path_prefix" default:"firehose"`
-	FoundationName        string `envconfig:"foundation_name" default:"cf"`
-	ResolveAppMetadata    bool   `envconfig:"resolve_app_metadata"`
-	NozzleID              string `envconfig:"nozzle_id" default:"local-nozzle"`
-	NozzleName            string `envconfig:"nozzle_name" default:"local-nozzle"`
-	NozzleZone            string `envconfig:"nozzle_zone" default:"local-nozzle"`
-	DebugNozzle           bool   `envconfig:"debug_nozzle"`
+	HeartbeatRate          int    `envconfig:"heartbeat_rate" default:"30"`
+	MetricsBufferDuration  int    `envconfig:"metrics_buffer_duration" default:"30"`
+	MetricsBatchSize       int    `envconfig:"metrics_batch_size" default:"200"`
+	MetricPathPrefix       string `envconfig:"metric_path_prefix" default:"firehose"`
+	FoundationName         string `envconfig:"foundation_name" default:"cf"`
+	ResolveAppMetadata     bool   `envconfig:"resolve_app_metadata"`
+	AppMetadataCachePeriod int    `envconfig:"app_info_cache_period" default:"-1"`
+	NozzleID               string `envconfig:"nozzle_id" default:"local-nozzle"`
+	NozzleName             string `envconfig:"nozzle_name" default:"local-nozzle"`
+	NozzleZone             string `envconfig:"nozzle_zone" default:"local-nozzle"`
+	DebugNozzle            bool   `envconfig:"debug_nozzle"`
 	// By default 'origin' label is prepended to metric name, however for runtime metrics (defined here) we add it as a metric label instead.
 	RuntimeMetricRegex string `envconfig:"runtime_metric_regex" default:"^(numCPUS|numGoRoutines|memoryStats\\..*)$"`
 	// If enabled, CounterEvents will be reported as cumulative Stackdriver metrics instead of two gauges (<metric>.delta


### PR DESCRIPTION
Enhancement to allow the cf app metadata cache to be configurable.  In the case of blue/green deploys, an app's name may change from what it was originally pushed as, and the resulting entries should reflect that.  

The implementation is almost identical to the [firehose-to-syslog](https://github.com/cloudfoundry-community/firehose-to-syslog) implementation, the main differences being this implementation defaults to permanent caching to maintain existing behavior and uses an in memory map as before instead of a third party key/value store.

I wanted to add some unit tests around app_info_repository, but because cfclient.Client isn't an interface, there was no easy way to mock it out for testing without adding new dependencies, which I didn't think appropriate.